### PR TITLE
don't use react-bootstrap's Row, Col. Refs STRIPES-427

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,9 @@
 # Change history for ui-checkin
 
 ## Release 1.2.0 in progress
-* use PropTypes, not React.PropTypes. Refs FOLIO-427.
+* use PropTypes, not React.PropTypes. Refs STRIPES-427.
 * Refactor to use pure stripes-connect. Fixes UICHKIN-4.
+* Use our implementations of `<Row>, <Col>`. Refs STRIPES-427.
 
 ## [1.1.1](https://github.com/folio-org/ui-checkin/tree/v1.1.1) (2017-08-31)
 [Full Changelog](https://github.com/folio-org/ui-checkin/compare/v1.1.0...v1.1.1)

--- a/CheckIn.js
+++ b/CheckIn.js
@@ -6,7 +6,7 @@ import Paneset from '@folio/stripes-components/lib/Paneset';
 import Pane from '@folio/stripes-components/lib/Pane';
 import Button from '@folio/stripes-components/lib/Button';
 import MultiColumnList from '@folio/stripes-components/lib/MultiColumnList';
-import { Row, Col } from 'react-bootstrap';
+import { Row, Col } from '@folio/stripes-components/lib/LayoutGrid';
 import TextField from '@folio/stripes-components/lib/TextField';
 
 const propTypes = {

--- a/package.json
+++ b/package.json
@@ -70,7 +70,6 @@
     "prop-types": "^15.6.0",
     "query-string": "^5.0.0",
     "react": "^15.4.2",
-    "react-bootstrap": "^0.31.1",
     "react-router-dom": "^4.0.0",
     "redux-form": "^7.0.3",
     "uuid": "^3.0.1"


### PR DESCRIPTION
Old versions of react-bootstrap barf up the Warning: Accessing PropTypes via the main React package is deprecated... message. We could just upgrade, but are working to deprecate react-bootstrap anyway.