### PR TITLE
Update circulation interface dependency UICHKIN-19

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Release 1.2.0 in progress
 * Dependency on item-storage: 5.0
+* Dependency on circulation: 3.0
 * use PropTypes, not React.PropTypes. Refs STRIPES-427.
 * Refactor to use pure stripes-connect. Fixes UICHKIN-4.
 * Use our implementations of `<Row>, <Col>`. Refs STRIPES-427.

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
       }
     ],
     "okapiInterfaces": {
-      "circulation": "2.2",
+      "circulation": "3.0",
       "configuration": "2.0",
       "item-storage": "5.0",
       "loan-policy-storage": "1.0",


### PR DESCRIPTION
Following the change in name of the metadata property (from metaData to metadata) the circulation interface version needs updating (from 2.2 to 3.0)