### PR TITLE
Change test results XML path

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -11,12 +11,5 @@ module.exports = (config) => {
     preprocessors
   };
 
-  // Set output directory for junit reporter
-  if (config.junitReporter) {
-    configuration.junitReporter = {
-      outputDir: 'artifacts/junit/Karma'
-    };
-  }
-
   config.set(configuration);
 };


### PR DESCRIPTION
Jenkins was reporting `None of the test reports contained any result`, since there was no JUnit-style report being generated.