### PR TITLE
Refactor barcode focus. Part of UITEST-55

### DIFF
--- a/src/CheckIn.js
+++ b/src/CheckIn.js
@@ -55,7 +55,7 @@ class CheckIn extends React.Component {
   }
 
   onSubmit(data) {
-    this.props.submithandler(data, this);
+    return this.props.submithandler(data, this);
   }
 
   handleSessionEnd = () => {

--- a/src/CheckIn.js
+++ b/src/CheckIn.js
@@ -37,6 +37,7 @@ class CheckIn extends React.Component {
   constructor() {
     super();
     this.barcodeEl = React.createRef();
+    this.onSubmit = this.onSubmit.bind(this);
   }
 
   state = {
@@ -53,10 +54,15 @@ class CheckIn extends React.Component {
     }
   }
 
+  onSubmit(data) {
+    this.props.submithandler(data, this);
+  }
+
   handleSessionEnd = () => {
     const { onSessionEnd } = this.props;
     this.setState({ showPickers: false });
     onSessionEnd();
+    setTimeout(() => this.focusInput());
   }
 
   showPickers = () => {
@@ -80,7 +86,6 @@ class CheckIn extends React.Component {
     const {
       handleSubmit,
       intl: { formatDate, formatMessage, formatTime },
-      submithandler,
       scannedItems,
       pristine,
       showInfo,
@@ -128,7 +133,7 @@ class CheckIn extends React.Component {
     const timeReturnedLabel = formatMessage({ id: 'ui-checkin.timeReturnedLabel' });
     const noItemsLabel = formatMessage({ id: 'ui-checkin.noItems' });
     return (
-      <form onSubmit={handleSubmit(submithandler)}>
+      <form onSubmit={handleSubmit(this.onSubmit)}>
         <div style={containerStyle}>
           <Paneset static>
             <Pane paneTitle="Scanned Items" defaultWidth="100%">
@@ -244,4 +249,5 @@ class CheckIn extends React.Component {
 
 export default reduxForm({
   form: 'CheckIn',
+  withRef: true
 })(injectIntl(CheckIn));

--- a/src/Scan.js
+++ b/src/Scan.js
@@ -213,8 +213,6 @@ class Scan extends React.Component {
   onSessionEnd() {
     this.clearResources();
     this.clearForm('CheckIn');
-    const checkInInst = this.checkInRef.current.wrappedInstance;
-    setTimeout(() => checkInInst.focusInput());
   }
 
   clearForm(formName) {
@@ -228,14 +226,14 @@ class Scan extends React.Component {
     this.props.mutator.loans.reset();
   }
 
-  onClickCheckin(data) {
+  onClickCheckin(data, checkInInst) {
     const { intl: { formatMessage } } = this.props;
     const fillOutMsg = formatMessage({ id: 'ui-checkin.fillOut' });
+
     if (!data.item || !data.item.barcode) {
       throw new SubmissionError({ item: { barcode: fillOutMsg } });
     }
 
-    const checkInInst = this.checkInRef.current.wrappedInstance;
     return this.fetchItemByBarcode(data.item.barcode)
       .then(item => this.fetchLoanByItemId(item.id))
       .then(loan => this.putReturn(loan, data.item.checkinDate, data.item.checkinTime))


### PR DESCRIPTION
It looks like because of the multiple hoc wrappers around `CheckIn` 

https://github.com/folio-org/ui-checkin/blob/master/src/CheckIn.js#L245-L247

we are not able to reference the `focusInput` function directly via `this.checkInRef.current.wrappedInstance`. This PR introduces couple small changes to make it easier for accessing `CheckIn` instance directly.