### PR TITLE
STCOM-394 User TextField InputRef prop.

### DIFF
--- a/src/CheckIn.js
+++ b/src/CheckIn.js
@@ -66,7 +66,7 @@ class CheckIn extends React.Component {
 
   focusInput() {
     if (this.barcodeEl.current) {
-      this.barcodeEl.current.getRenderedComponent().focusInput();
+      this.barcodeEl.current.focus();
     }
   }
 
@@ -260,7 +260,7 @@ class CheckIn extends React.Component {
                         validationEnabled={false}
                         placeholder={scanBarcodeMsg}
                         aria-label={itemIdLabel}
-                        ref={this.barcodeEl}
+                        inputRef={this.barcodeEl}
                         withRef
                         fullWidth
                         component={TextField}

--- a/src/CheckIn.js
+++ b/src/CheckIn.js
@@ -261,7 +261,6 @@ class CheckIn extends React.Component {
                         placeholder={scanBarcodeMsg}
                         aria-label={itemIdLabel}
                         inputRef={this.barcodeEl}
-                        withRef
                         fullWidth
                         component={TextField}
                         data-test-check-in-barcode


### PR DESCRIPTION
# Previously....
Checkin had to resort to pushing a ref through the HOC's that wrap TextField in order to properly obtain a ref so that it could call instance methods of TextField (`focusInput()`)
This isn't an ideal way for things to be shaped.

# Now...
TextField has a prop: `inputRef` that can be used to obtain a direct ref to the `<input>` rendered by TextField. This will punch through any HOC's without needing to rely on ref-forwarding or `withRef` API. Any usage of `focusInput()` or `getInput()` can be replaced by the native `focus()`. In this case, the API to dig up the rendered component (`getRenderedComponent()`) can be removed as well.