### PR TITLE
Improve ui-checkin BigTest code coverage to >80%. Part of UICHKIN-69.

### DIFF
--- a/src/components/MultipieceModal/MultipieceModal.js
+++ b/src/components/MultipieceModal/MultipieceModal.js
@@ -18,10 +18,16 @@ const MultipieceModal = (props) => {
 
   const footer = (
     <ModalFooter>
-      <Button buttonStyle="primary" onClick={() => onConfirm()}>
+      <Button
+        buttonStyle="primary"
+        data-test-checkin-button
+        onClick={() => onConfirm()}
+      >
         <FormattedMessage id="ui-checkin.multipieceModal.checkIn" />
       </Button>
-      <Button onClick={onClose}>
+      <Button
+        onClick={onClose}
+      >
         <FormattedMessage id="ui-checkin.multipieceModal.cancel" />
       </Button>
     </ModalFooter>
@@ -29,6 +35,7 @@ const MultipieceModal = (props) => {
   return (
     <Modal
       id="multipiece-modal"
+      data-test-multi-piece-modal
       size="small"
       footer={footer}
       dismissible

--- a/test/bigtest/interactors/check-in.js
+++ b/test/bigtest/interactors/check-in.js
@@ -39,6 +39,7 @@ import {
 
 @interactor class MultiPieceModalInteractor {
   present = isPresent('[data-test-checkin-button]');
+  clickCheckinBtn = clickable('[data-test-checkin-button]');
 }
 
 @interactor class CheckInInteractor {

--- a/test/bigtest/interactors/check-in.js
+++ b/test/bigtest/interactors/check-in.js
@@ -37,10 +37,15 @@ import {
   clickConfirmButton = clickable('[data-test-confirm-button]');
 }
 
+@interactor class MultiPieceModalInteractor {
+  present = isPresent('[data-test-checkin-button]');
+}
+
 @interactor class CheckInInteractor {
   processDate = new DatepickerInteractor('[data-test-process-date]');
   processTime = new TimepickerInteractor('[data-test-process-time]');
   confirmModal = new ConfirmStatusModal('[data-test-confirm-status-modal]');
+  multiPieceModal = new MultiPieceModalInteractor('[data-test-multi-piece-modal]');
 
   selectElipse = clickable('[data-test-elipse-select] button');
   selectLoanDetails = clickable('[data-test-loan-details]');

--- a/test/bigtest/tests/check-in-test.js
+++ b/test/bigtest/tests/check-in-test.js
@@ -279,4 +279,26 @@ describe('CheckIn', () => {
       expect(checkIn.multiPieceModal.present).to.be.true;
     });
   });
+
+  describe('closes multipiece item modal', () => {
+    beforeEach(async function () {
+      this.server.create('item', 'withLoan', {
+        barcode: 9676761472501,
+        title: 'Best Book Ever',
+        materialType: {
+          name: 'book'
+        },
+        numberOfPieces: 2,
+        instanceId : 'lychee',
+        holdingsRecordId : 'apple'
+      });
+
+      await checkIn.barcode('9676761472501').clickEnter();
+      await checkIn.multiPieceModal.clickCheckinBtn();
+    });
+
+    it('hides multipiece item modal', () => {
+      expect(checkIn.multiPieceModal.present).to.be.false;
+    });
+  });
 });

--- a/test/bigtest/tests/check-in-test.js
+++ b/test/bigtest/tests/check-in-test.js
@@ -258,4 +258,25 @@ describe('CheckIn', () => {
       expect(checkIn.printHoldSlipItemPresent).to.be.true;
     });
   });
+
+  describe('showing multipiece item modal', () => {
+    beforeEach(async function () {
+      this.server.create('item', 'withLoan', {
+        barcode: 9676761472501,
+        title: 'Best Book Ever',
+        materialType: {
+          name: 'book'
+        },
+        numberOfPieces: 2,
+        instanceId : 'lychee',
+        holdingsRecordId : 'apple'
+      });
+
+      await checkIn.barcode('9676761472501').clickEnter();
+    });
+
+    it('shows multipiece item modal', () => {
+      expect(checkIn.multiPieceModal.present).to.be.true;
+    });
+  });
 });


### PR DESCRIPTION
@magdazacharska I'm hoping this PR will bring `ui-checkin` to > 80%.

More tests were added as part of another PR https://github.com/folio-org/ui-checkin/pull/138

Sonarcloud shows me 81.9% coverage after this PR is merged:

https://sonarcloud.io/component_measures?branch=UICHKIN-69&id=org.folio%3Aui-checkin&metric=coverage

I think we can improve this further but let's try to merge this one in and see where we are.