### PR TITLE
trim whitespace padding from item barcodes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change history for ui-checkin
 
+## 1.7.0 (IN PROGRESS)
+
+* Trim whitespace padding from item barcodes to avoid server errors. Fixes UICHKIN-93.
+
 ##  [1.6.0](https://github.com/folio-org/ui-checkin/tree/v1.6.0) (2019-03-16)
 [Full Changelog](https://github.com/folio-org/ui-checkin/compare/v1.5.0...v1.6.0)
 

--- a/src/Scan.js
+++ b/src/Scan.js
@@ -211,7 +211,7 @@ class Scan extends React.Component {
     const requestData = {
       servicePointId,
       checkInDate,
-      itemBarcode: barcode,
+      itemBarcode: barcode.trim(),
     };
 
     return checkIn.POST(requestData)


### PR DESCRIPTION
Submitting an item barcode with leading or trailing whitespace to the
endpoint `circulation/check-in-by-barcode` causes it to fail with a 500
and the response, "Failed to contact storage module:
java.io.IOException: Connection reset by peer".

Fixes [UICHKIN-93](https://issues.folio.org/browse/UICHKIN-93)