### PR TITLE
UIIN-678 avoid buggy react-to-print version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change history for ui-checkin
 
+## 1.9.0 (IN PROGRESS)
+
+* Update `react-to-print` to accept React via `peerDependencies`. UIIN-678.
+
 ## [1.8.0](https://github.com/folio-org/ui-checkin/tree/v1.8.0) (2019-07-24)
 [Full Changelog](https://github.com/folio-org/ui-checkin/compare/v1.7.0...v1.8.0)
 

--- a/package.json
+++ b/package.json
@@ -89,7 +89,7 @@
     "react-hot-loader": "^4.3.12",
     "react-intl": "^2.4.0",
     "react-router-dom": "^4.0.0",
-    "react-to-print": "^1.0.21",
+    "react-to-print": "^2.3.2",
     "redux-form": "^7.0.3"
   },
   "peerDependencies": {

--- a/src/components/PrintButton/PrintButton.js
+++ b/src/components/PrintButton/PrintButton.js
@@ -39,6 +39,7 @@ class PrintButton extends React.Component {
       <React.Fragment>
         <ReactToPrint
           onBeforePrint={onBeforePrint}
+          removeAfterPrint
           trigger={() => <Button {...btnProps}>{children}</Button>}
           content={() => this.printContentRef.current}
         />


### PR DESCRIPTION
`react-to-print` v1 depends directly on React with a caret dep on
version 16. This has the effect of pulling in the most-recent React 16.x
build into any bundle that uses this module, even if that module has a
more strict tilde dep on a less-than-current React minor release.
Whatnow? Say an app depends on React ~16.8.0; React 16.9.0 still gets
into the bundle because of the loose (caret) direct dependency in
react-to-print v1. This was fixed in
https://github.com/gregnb/react-to-print/pull/53 and appears to be the
straw that broke the v1.0-camel's back.

v2 also changed from using a `window` to an `iframe` to handle printing,
but does not automatically clean up the iframe after printing is
finished. This appears to be an oversight, but rather than introduce
another breaking change, they just added the prop in release 2.3.0.

Refs [UIIN-678](https://issues.folio.org/browse/UIIN-678)