### PR TITLE
UICHKIN-110: Provide correct backend permissions in 'Check in: All permissions" permission

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Change history for ui-checkin
 
+## [1.10.0] (IN PROGRESS)
+* Provide correct backend permissions in 'Check in: All permissions" permission. Fixes UICHKIN-110.
+
 ## [1.9.0](https://github.com/folio-org/ui-checkin/tree/v1.9.0) (2019-09-11)
 [Full Changelog](https://github.com/folio-org/ui-checkin/compare/v1.8.0...v1.9.0)
 

--- a/package.json
+++ b/package.json
@@ -46,7 +46,10 @@
           "circulation-storage.all",
           "configuration.all",
           "users.collection.get",
-          "module.checkin.enabled"
+          "usergroups.collection.get",
+          "module.checkin.enabled",
+          "inventory.items.collection.get",
+          "inventory-storage.service-points.collection.get"
         ]
       }
     ]


### PR DESCRIPTION
## Purpose

Handle errors with missed backend sub-permissions when a user has only **Check in: All permissions** as a part of [UICHKIN-110](https://issues.folio.org/browse/UICHKIN-110).

## Screenshot

<img width="1101" alt="Screen Shot 2019-11-15 at 12 17 42" src="https://user-images.githubusercontent.com/40821852/68935862-f92fa600-07a1-11ea-8812-8113ca33472f.png">
