### PR TITLE
UICHKIN-138: fix bug on checking in item with no active requests

### DIFF
--- a/src/Scan.js
+++ b/src/Scan.js
@@ -255,12 +255,12 @@ class Scan extends React.Component {
 
   fetchRequests(checkinResp) {
     const { item } = checkinResp;
-    const query = `(itemId==${item.id})`;
+    const query = `(itemId==${item.id} and (status=="Open - Awaiting pickup" or status=="Open - Awaiting delivery"))`;
     const { mutator } = this.props;
     mutator.requests.reset();
     return mutator.requests.GET({ params: { query } }).then((requests) => {
       if (requests.length) {
-        const nextRequest = minBy(requests, 'position');
+        const nextRequest = requests[0];
         nextRequest.item = item;
         checkinResp.nextRequest = nextRequest;
         this.setState({ nextRequest });


### PR DESCRIPTION
## Purpose
My last PR broke things a little bit. I changed the code to fetch all requests of an item, including closed requests which don't have a position field. So if an array of closed requests is returned from the back-end, then the `if (requests.length)` condition is truthy, but the code which runs on this condition fails: `const nextRequest = minBy(requests, 'position');`
## Approach
* fetch requests only with statuses "Open - Awaiting pickup" or "Open - Awaiting delivery"
* The line `const nextRequest = minBy(requests, 'position');`  was changed to `const nextRequest = requests[0];`  since if a request's status is  "Open - Awaiting pickup" or "Open - Awaiting delivery", than it's position is `1`.
