### PR TITLE
Remove explicit fake-xml-http-request in advance for the stripes-core

### DIFF
--- a/package.json
+++ b/package.json
@@ -98,8 +98,5 @@
   "peerDependencies": {
     "@folio/stripes": "^2.0.0",
     "react": "*"
-  },
-  "resolutions": {
-    "fake-xml-http-request": "2.0.0"
   }
 }


### PR DESCRIPTION
Having multiple versions of the fake-xml-http-request can prevent patching.