### PR TITLE
UICHKIN-146 update stripes to receive countries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change history for ui-checkin
 
+## 1.10.1 (IN PROGRESS)
+
+* Update `@folio/stripes` dependency to receive country list. Required for UICHKIN-146.
+
 ## [1.10.0](https://github.com/folio-org/ui-checkin/tree/v1.10.0) (2019-12-4)
 [Full Changelog](https://github.com/folio-org/ui-checkin/compare/v1.9.0...v1.10.0)
 

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "@bigtest/mocha": "^0.5.0",
     "@bigtest/react": "^0.1.2",
     "@folio/eslint-config-stripes": "^3.2.1",
-    "@folio/stripes": "^2.0.0",
+    "@folio/stripes": "^2.12.1",
     "@folio/stripes-cli": "^1.4.0",
     "@folio/stripes-core": "^3.0.1",
     "babel-eslint": "^9.0.0",
@@ -96,7 +96,7 @@
     "redux-form": "^7.0.3"
   },
   "peerDependencies": {
-    "@folio/stripes": "^2.0.0",
+    "@folio/stripes": "^2.12.1",
     "react": "*"
   }
 }


### PR DESCRIPTION
A list of countries is provided in newer versions of stripes-components,
so we need to update the `@folio/stripes` dependency to get that newer
version in order to use those values.

Refs [UICHKIN-146](https://issues.folio.org/browse/UICHKIN-146)