### PR TITLE
UICHKIN-127: Display effective call number prefix, call number, and call number suffix at check in

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,4 +1,21 @@
 {
   "parser": "babel-eslint",
-  "extends": "@folio/eslint-config-stripes"
+  "extends": "@folio/eslint-config-stripes",
+  "plugins": [
+    "no-only-tests"
+  ],
+  "rules": {
+    "no-only-tests/no-only-tests": [
+      "error",
+      {
+        "block": [
+          "describe",
+          "it"
+        ],
+        "focus": [
+          "only"
+        ]
+      }
+    ]
+  }
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [1.11.0] (IN PROGRESS)
 
 * Provide two options for barcode tokens on staff slips. Refs UICIRC-393.
+* Display effective call number prefix, call number, and call number suffix at check in. Refs UICHKIN-127.
 
 ## [1.10.0](https://github.com/folio-org/ui-checkin/tree/v1.10.0) (2019-12-4)
 [Full Changelog](https://github.com/folio-org/ui-checkin/compare/v1.9.0...v1.10.0)

--- a/package.json
+++ b/package.json
@@ -73,6 +73,7 @@
     "babel-polyfill": "^6.26.0",
     "chai": "^4.1.2",
     "eslint": "^5.6.0",
+    "eslint-plugin-no-only-tests": "^2.4.0",
     "mocha": "^5.2.0",
     "react": "^16.4.1",
     "react-dom": "^16.4.1",

--- a/src/CheckIn.js
+++ b/src/CheckIn.js
@@ -1,4 +1,7 @@
-import get from 'lodash/get';
+import {
+  get,
+  compact,
+} from 'lodash';
 import React from 'react';
 import PropTypes from 'prop-types';
 import { Field, reduxForm } from 'redux-form';
@@ -304,9 +307,10 @@ class CheckIn extends React.Component {
         const inTransitSp = get(loan, ['item', 'inTransitDestinationServicePoint', 'name']);
         return (inTransitSp) ? `${status} - ${inTransitSp}` : status;
       },
-      'callNumber': (loan) => {
-        const callNumber = `${get(loan, ['item', 'callNumber'])}`;
-        return callNumber !== 'undefined' ? callNumber : ' ';
+      'callNumber': loan => {
+        const callNumberComponents = get(loan, ['item', 'callNumberComponents'], {});
+
+        return compact([callNumberComponents.prefix, callNumberComponents.callNumber, callNumberComponents.suffix]).join(' ');
       },
       ' ': loan => this.renderActions(loan),
     };

--- a/test/bigtest/interactors/check-in.js
+++ b/test/bigtest/interactors/check-in.js
@@ -88,7 +88,6 @@ import MultiColumnListInteractor from '@folio/stripes-components/lib/MultiColumn
   checkinNoteModal = new CheckinNoteModalInteractor();
   selectEllipse = clickable('[data-test-elipse-select] button');
   checkedInItemsList = scoped('#list-items-checked-in', MultiColumnListInteractor);
-  checkedInItemsListEmptyMessage = text('[data-test-checked-in-items] [class*=mclEmptyMessage---]');
   selectLoanDetails = clickable('[data-test-loan-details]');
   selectPatronDetails = clickable('[data-test-patron-details]');
   selectItemDetails = clickable('[data-test-item-details]');

--- a/test/bigtest/interactors/check-in.js
+++ b/test/bigtest/interactors/check-in.js
@@ -87,7 +87,7 @@ import MultiColumnListInteractor from '@folio/stripes-components/lib/MultiColumn
   missingItemModal = new MissingItemModalInteractor();
   checkinNoteModal = new CheckinNoteModalInteractor();
   selectEllipse = clickable('[data-test-elipse-select] button');
-  checkedInItemsList = scoped('[data-test-checked-in-items] div', MultiColumnListInteractor);
+  checkedInItemsList = scoped('#list-items-checked-in', MultiColumnListInteractor);
   checkedInItemsListEmptyMessage = text('[data-test-checked-in-items] [class*=mclEmptyMessage---]');
   selectLoanDetails = clickable('[data-test-loan-details]');
   selectPatronDetails = clickable('[data-test-patron-details]');

--- a/test/bigtest/tests/check-in-test.js
+++ b/test/bigtest/tests/check-in-test.js
@@ -86,7 +86,7 @@ describe('CheckIn', () => {
       expect(checkIn.checkedInItemsListEmptyMessage).to.equal('');
     });
 
-    describe.only('ending the session', () => {
+    describe('ending the session', () => {
       beforeEach(async () => {
         await checkIn.endSession();
       });
@@ -94,6 +94,27 @@ describe('CheckIn', () => {
       it('clears the list', () => {
         expect(checkIn.hasCheckedInItems).to.be.false;
       });
+    });
+  });
+
+  describe('showing call number', () => {
+    beforeEach(async function () {
+      const barcode = '9676761472501';
+
+      this.server.create('item', 'withLoan', {
+        barcode,
+        callNumberComponents: {
+          prefix: 'prefix',
+          callNumber: 'callNumber',
+          suffix: 'suffix',
+        },
+      });
+
+      await checkIn.barcode(barcode).clickEnter();
+    });
+
+    it('should be properly formatted', () => {
+      expect(checkIn.checkedInItemsList.rows(0).cells(3).text).to.equal('prefix callNumber suffix');
     });
   });
 

--- a/test/bigtest/tests/check-in-test.js
+++ b/test/bigtest/tests/check-in-test.js
@@ -83,7 +83,7 @@ describe('CheckIn', () => {
     });
 
     it('should hide item list empty message during checkin', () => {
-      expect(checkIn.checkedInItemsListEmptyMessage).to.equal('');
+      expect(checkIn.checkedInItemsList.displaysEmptyMessage).to.be.false;
     });
 
     describe('ending the session', () => {
@@ -126,7 +126,7 @@ describe('CheckIn', () => {
     });
 
     it('should hide item list empty message during check in', () => {
-      expect(checkIn.checkedInItemsListEmptyMessage).to.equal('');
+      expect(checkIn.checkedInItemsList.displaysEmptyMessage).to.be.false;
     });
   });
 


### PR DESCRIPTION
## Purpose

Display effective call number prefix, call number, and call number suffix during check in in the scope of [UICHKIN-127](https://issues.folio.org/browse/UICHKIN-127).

## Screenshot
<img width="1153" alt="Screen Shot 2020-01-08 at 19 50 27" src="https://user-images.githubusercontent.com/40821852/72002475-2bb0c900-3250-11ea-9b92-297fa9b63453.png">
