### PR TITLE
bump to version 2.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Change history for ui-checkin
 
-## [1.11.0] (IN PROGRESS)
+## [2.0.0] (IN PROGRESS)
 
 * Provide two options for barcode tokens on staff slips. Refs UICIRC-393.
 * Display effective call number prefix, call number, and call number suffix at check in. Refs UICHKIN-127.
@@ -8,6 +8,7 @@
 * Make the Check in ellipsis accessible. Refs UICHKIN-134.
 * Add 'in-house use' column to checked-in items table. Refs UICHKIN-100.
 * Security update eslint to >= 6.2.1 or eslint-util >= 1.4.1. Refs. UICHKIN-150.
+* Migrate to `stripes` `v3.0.0` and move `react-intl` and `react-router` to peerDependencies.
 
 ## [1.10.0](https://github.com/folio-org/ui-checkin/tree/v1.10.0) (2019-12-4)
 [Full Changelog](https://github.com/folio-org/ui-checkin/compare/v1.9.0...v1.10.0)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@folio/checkin",
-  "version": "1.10.0",
+  "version": "2.0.0",
   "description": "Item Check-in",
   "repository": "folio-org/ui-checkin",
   "publishConfig": {
@@ -67,9 +67,9 @@
     "@bigtest/mocha": "^0.5.0",
     "@bigtest/react": "^0.1.2",
     "@folio/eslint-config-stripes": "^5.1.0",
-    "@folio/stripes": "^2.13.0",
+    "@folio/stripes": "^3.0.0",
     "@folio/stripes-cli": "^1.11.0",
-    "@folio/stripes-core": "^3.12.0",
+    "@folio/stripes-core": "^4.0.0",
     "babel-eslint": "^10.0.3",
     "chai": "^4.1.2",
     "core-js": "^3.6.4",
@@ -93,13 +93,13 @@
     "prop-types": "^15.6.0",
     "react-barcode": "^1.3.2",
     "react-hot-loader": "^4.3.12",
-    "react-intl": "^2.4.0",
-    "react-router-dom": "^4.0.0",
     "react-to-print": "^2.3.2",
     "redux-form": "^7.0.3"
   },
   "peerDependencies": {
-    "@folio/stripes": "^2.13.0",
-    "react": "*"
+    "@folio/stripes": "^3.0.0",
+    "react": "*",
+    "react-intl": "^2.4.0",
+    "react-router-dom": "^4.0.0"
   }
 }


### PR DESCRIPTION
Why a new major version?

* bump the `@folio/stripes` peer to `v3.0.0`
* move `react-router` related things to peerDependencies
* move `react-intl` to peerDependencies