### PR TITLE
peer-deps must also be dev deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
     "react": "^16.4.1",
     "react-dom": "^16.4.1",
     "react-redux": "^5.0.7",
-    "react-router-dom": "^4.0.0"
+    "react-router-dom": "^4.0.0",
     "redux": "^4.0.0",
     "regenerator-runtime": "^0.13.3",
     "sinon": "^6.3.4",

--- a/package.json
+++ b/package.json
@@ -80,6 +80,7 @@
     "react": "^16.4.1",
     "react-dom": "^16.4.1",
     "react-redux": "^5.0.7",
+    "react-router-dom": "^4.0.0"
     "redux": "^4.0.0",
     "regenerator-runtime": "^0.13.3",
     "sinon": "^6.3.4",


### PR DESCRIPTION
Silly yarn isn't clever enough to include peer-deps as dev-deps for the
purposes of testing. C'mon.