### PR TITLE
UICHKIN-162: Replace placeholder in-house use icon with the official …

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 * Migrate to `stripes` `v3.0.0` and move `react-intl` and `react-router` to peerDependencies.
 * Fix accessibility problems. Refs UICHKIN-159.
 * Add fee/fine details button. Refs UICHKIN-125.
+* Replace placeholder in-house use icon with the official icon. Refs UICHKIN-162.
 
 ## [1.10.0](https://github.com/folio-org/ui-checkin/tree/v1.10.0) (2019-12-4)
 [Full Changelog](https://github.com/folio-org/ui-checkin/compare/v1.9.0...v1.10.0)

--- a/src/CheckIn.js
+++ b/src/CheckIn.js
@@ -350,7 +350,11 @@ class CheckIn extends React.Component {
       },
       'barcode': loan => `${get(loan, ['item', 'barcode'])}`,
       'location': loan => `${get(loan, ['item', 'location', 'name'])}`,
-      'inHouseUse': loan => { return get(loan, 'inHouseUse') ? <Icon icon="plus-sign" size="small" /> : ''; },
+      'inHouseUse': loan => {
+        return get(loan, 'inHouseUse')
+          ? <Icon icon="house" iconClassName={styles['house-icon']} />
+          : '';
+      },
       'status': loan => {
         const status = `${get(loan, ['item', 'status', 'name'])}`;
         const inTransitSp = get(loan, ['item', 'inTransitDestinationServicePoint', 'name']);

--- a/src/checkin.css
+++ b/src/checkin.css
@@ -8,3 +8,8 @@
   font-size: var(--font-size-small);
   line-height: var(--line-height);
 }
+
+.house-icon {
+  height: 1.8em;
+  width: 4.5em;
+}


### PR DESCRIPTION
### Purpose
Show `In-house use` icon during in-house use. Story [UICHKIN-162](https://issues.folio.org/browse/UICHKIN-162).

### Screenshot
![In_house_icon_centered_ _larger](https://user-images.githubusercontent.com/49517355/76539151-0aa36900-6489-11ea-9f12-d696a358703f.png)
