### PR TITLE
UICHKIN-174: Check for accounts.collection.get permission

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change history for ui-checkin
 
+## [2.1.0] IN PROGRESS
+
+* Check for `accounts.collection.get` permission before rendering fee/fines components. Fixes UICHKIN-174.
+
 ## [2.0.0] (https://github.com/folio-org/ui-checkin/tree/v2.0.0) (2019-03-13)
 [Full Changelog](https://github.com/folio-org/ui-checkin/compare/v1.10.0...v2.0.0)
 

--- a/src/CheckIn.js
+++ b/src/CheckIn.js
@@ -29,6 +29,7 @@ import {
   Dropdown,
 } from '@folio/stripes/components';
 import getEffectiveCallNumber from '@folio/stripes-util/lib/effectiveCallNumber';
+import { IfPermission } from '@folio/stripes/core';
 
 import PrintButton from './components/PrintButton';
 import FeesFinesOwnedStatus from './components/FeesFinesOwnedStatus';
@@ -262,11 +263,13 @@ class CheckIn extends React.Component {
               <FormattedMessage id="ui-checkin.itemDetails" />
             </Button>
           </div>
-          <FeeFineDetailsButton
-            userId={loan.userId}
-            itemId={loan.itemId}
-            mutator={this.props.mutator}
-          />
+          <IfPermission perm="accounts.collection.get">
+            <FeeFineDetailsButton
+              userId={loan.userId}
+              itemId={loan.itemId}
+              mutator={this.props.mutator}
+            />
+          </IfPermission>
           {loan.userId &&
             <Button
               role="menuitem"
@@ -335,11 +338,13 @@ class CheckIn extends React.Component {
             null
           }
           { loan.userId && loan.itemId &&
-            <FeesFinesOwnedStatus
-              userId={loan.userId}
-              itemId={loan.itemId}
-              mutator={this.props.mutator}
-            />
+            <IfPermission perm="accounts.collection.get">
+              <FeesFinesOwnedStatus
+                userId={loan.userId}
+                itemId={loan.itemId}
+                mutator={this.props.mutator}
+              />
+            </IfPermission>
           }
         </div>
       ),


### PR DESCRIPTION
https://issues.folio.org/browse/UICHKIN-174

This PR wraps fees/fines related components in `< IfPermission>` block to prevent from throwing an error described in UICHKIN-174 when user doesn't have the `accounts.collection.get` permission.

I tried to add tests to this but I unfortunately failed. The BigTest setup in ui-checkin is a bit different from other modules with setup similar to: 

https://github.com/folio-org/ui-checkin/blob/master/.stripesclirc.js

For some reason I could not customize it to add the ability to define what permissions should be used during testing. We will need some more time to review it.

