### PR TITLE
UICHKIN-175: Fix import path to stripes util

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [2.1.0] IN PROGRESS
 
 * Check for `accounts.collection.get` permission before rendering fee/fines components. Fixes UICHKIN-174.
+* Fix import path to stripes util. Fixes UICHKIN-175.
 
 ## [2.0.0] (https://github.com/folio-org/ui-checkin/tree/v2.0.0) (2019-03-13)
 [Full Changelog](https://github.com/folio-org/ui-checkin/compare/v1.10.0...v2.0.0)

--- a/src/CheckIn.js
+++ b/src/CheckIn.js
@@ -28,7 +28,7 @@ import {
   Tooltip,
   Dropdown,
 } from '@folio/stripes/components';
-import getEffectiveCallNumber from '@folio/stripes-util/lib/effectiveCallNumber';
+import { effectiveCallNumber } from '@folio/stripes/util';
 import { IfPermission } from '@folio/stripes/core';
 
 import PrintButton from './components/PrintButton';
@@ -365,7 +365,7 @@ class CheckIn extends React.Component {
         const inTransitSp = get(loan, ['item', 'inTransitDestinationServicePoint', 'name']);
         return (inTransitSp) ? `${status} - ${inTransitSp}` : status;
       },
-      'effectiveCallNumber': loan => getEffectiveCallNumber(loan),
+      'effectiveCallNumber': loan => effectiveCallNumber(loan),
       ' ': loan => this.renderActions(loan),
     };
 


### PR DESCRIPTION
https://issues.folio.org/browse/UICHKIN-175

This PR replaces the path to stripes util from `@folio/stripes-util` to `@folio/stripes/util`