### PR TITLE
UICHKIN-126: Show confirmation modal when a withdrawn item is checked in

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Check for `accounts.collection.get` permission before rendering fee/fines components. Fixes UICHKIN-174.
 * Fix import path to stripes util. Fixes UICHKIN-175.
+* Show confirmation modal when item with withdrawn status is checked in. Refs UICHKIN-126.
 * Purge `intlShape` in prep for `react-intl` `v4` migration. Refs STRIPES-672.
 
 ## [2.0.0] (https://github.com/folio-org/ui-checkin/tree/v2.0.0) (2019-03-13)

--- a/src/consts.js
+++ b/src/consts.js
@@ -5,6 +5,7 @@ const statuses = {
   CHECK_IN: 'Check in',
   AWAITING_DELIVERY: 'Awaiting delivery',
   DECLARED_LOST: 'Declared lost',
+  WITHDRAWN: 'Withdrawn',
 };
 
 const requestTypes = {

--- a/test/bigtest/interactors/check-in.js
+++ b/test/bigtest/interactors/check-in.js
@@ -19,6 +19,7 @@ import CheckinNoteModalInteractor from './checkin-note-modal';
 import MissingItemModalInteractor from './missing-item-modal';
 import MultiPieceModalInteractor from './multi-piece-modal';
 import DeclaredLostModalInteractor from './declared-lost-modal';
+import WithdrawnModalInteractor from './withdrawn-modal';
 
 @interactor class CheckInInteractor {
   processDate = new DatepickerInteractor('[data-test-process-date]');
@@ -28,6 +29,8 @@ import DeclaredLostModalInteractor from './declared-lost-modal';
   missingItemModal = new MissingItemModalInteractor();
   checkinNoteModal = new CheckinNoteModalInteractor();
   declaredLostModal = new DeclaredLostModalInteractor();
+  withdrawnModal = new WithdrawnModalInteractor();
+
   selectEllipse = clickable('[data-test-elipse-select] button');
   checkedInItemsList = scoped('#list-items-checked-in', MultiColumnListInteractor);
   selectLoanDetails = clickable('[data-test-loan-details] a');

--- a/test/bigtest/interactors/withdrawn-modal.js
+++ b/test/bigtest/interactors/withdrawn-modal.js
@@ -4,10 +4,10 @@ import {
   isPresent,
 } from '@bigtest/interactor';
 
-@interactor class DeclaredLostModal {
-  defaultScope = '#test-declaredLost-modal';
+@interactor class WithdrawnModal {
+  defaultScope = '#test-withdrawn-modal';
   present = isPresent('[data-test-confirmation-modal-confirm-button]');
   clickConfirm = clickable('[data-test-confirmation-modal-confirm-button]');
 }
 
-export default DeclaredLostModal;
+export default WithdrawnModal;

--- a/test/bigtest/tests/check-in-test.js
+++ b/test/bigtest/tests/check-in-test.js
@@ -565,6 +565,55 @@ describe('CheckIn', () => {
     });
   });
 
+  describe('showing withdrawn modal', () => {
+    beforeEach(async function () {
+      this.server.create('item', 'withLoan', {
+        barcode: 9676761472501,
+        title: 'Best Book Ever',
+        status: {
+          name: 'Withdrawn',
+        },
+        materialType: {
+          name: 'book',
+        },
+        numberOfPieces: 1,
+        instanceId: 'lychee',
+        holdingsRecordId: 'apple',
+      });
+
+      await checkIn.barcode('9676761472501').clickEnter();
+    });
+
+    it('shows withdrawnmodal', () => {
+      expect(checkIn.withdrawnModal.present).to.be.true;
+    });
+  });
+
+  describe('closes withdrawn modal', () => {
+    beforeEach(async function () {
+      this.server.create('item', 'withLoan', {
+        barcode: 9676761472501,
+        title: 'Best Book Ever',
+        status: {
+          name: 'Withdrawn',
+        },
+        materialType: {
+          name: 'book',
+        },
+        numberOfPieces: 1,
+        instanceId: 'lychee',
+        holdingsRecordId: 'apple',
+      });
+
+      await checkIn.barcode('9676761472501').clickEnter();
+      await checkIn.withdrawnModal.clickConfirm();
+    });
+
+    it('hides withdrawn modal', () => {
+      expect(checkIn.withdrawnModal.present).to.be.false;
+    });
+  });
+
   describe('showing missing item modal', () => {
     beforeEach(async function () {
       this.server.create('item', 'withLoan', {

--- a/translations/ui-checkin/en.json
+++ b/translations/ui-checkin/en.json
@@ -71,5 +71,8 @@
   "action.printTransitSlip": "Print transit slip",
   "actions.moreDetails": "Get more details about this item",
   "declaredLostModal.heading": "Check in Declared lost item?",
-  "declaredLostModal.message": "<strong>{title} ({materialType})</strong> (Barcode: {barcode}) has the item status <strong>Declared lost.</strong>"
+  "declaredLostModal.message": "<strong>{title} ({materialType})</strong> (Barcode: {barcode}) has the item status <strong>Declared lost.</strong>",
+  "withdrawnModal.heading": "Check in Withdrawn item?",
+  "withdrawnModal.suppressedMessage": "<strong>{title} ({materialType})</strong> (Barcode: {barcode}) has the item status <strong>Withdrawn </strong> and is suppressed from discovery.",
+  "withdrawnModal.notSuppressedMessage": "<strong>{title} ({materialType})</strong> (Barcode: {barcode}) has the item status <strong>Withdrawn</strong>."
 }


### PR DESCRIPTION
### Purpose

Show confirmation modal when a withdrawn item is checked in

### Link

https://issues.folio.org/browse/UICHKIN-126

### Printscreen

![checkin](https://user-images.githubusercontent.com/63545/80752020-d5b2aa80-8af8-11ea-976c-7f3bc24dedba.png)
