### PR TITLE
UICHKIN-157 - Refactor forms to use final-form

### DIFF
--- a/package.json
+++ b/package.json
@@ -97,7 +97,8 @@
     "react-barcode": "^1.3.2",
     "react-hot-loader": "^4.3.12",
     "react-to-print": "^2.3.2",
-    "redux-form": "^7.0.3"
+    "final-form": "^4.19.1",
+    "react-final-form": "^6.4.0"
   },
   "peerDependencies": {
     "@folio/stripes": "^3.0.0",

--- a/src/CheckIn.js
+++ b/src/CheckIn.js
@@ -380,8 +380,8 @@ class CheckIn extends React.Component {
       loading,
     } = this.props;
 
-    const { 
-      hasSubmitErrors = false, 
+    const {
+      hasSubmitErrors = false,
       submitErrors = {},
     } = form.getState();
 
@@ -575,4 +575,4 @@ class CheckIn extends React.Component {
 
 export default stripesFinalForm({
   navigationCheck: true,
-})(injectIntl(CheckIn));  
+})(injectIntl(CheckIn));

--- a/src/CheckIn.js
+++ b/src/CheckIn.js
@@ -61,7 +61,6 @@ class CheckIn extends React.Component {
       current: PropTypes.instanceOf(Element)
     }),
     onSessionEnd: PropTypes.func,
-    change: PropTypes.func,
     resources: PropTypes.shape({
       checkinSettings: PropTypes.shape({
         records: PropTypes.arrayOf(PropTypes.object),
@@ -153,7 +152,7 @@ class CheckIn extends React.Component {
   }
 
   showPickers = () => {
-    const { change, intl: { timeZone } } = this.props;
+    const { form: { change }, intl: { timeZone } } = this.props;
     const now = moment.tz(timeZone);
     change('item.checkinDate', now.format());
     change('item.checkinTime', now.format());

--- a/src/CheckIn.js
+++ b/src/CheckIn.js
@@ -57,6 +57,9 @@ class CheckIn extends React.Component {
     barcodeRef: PropTypes.shape({
       current: PropTypes.instanceOf(Element)
     }),
+    formRef: PropTypes.shape({
+      current: PropTypes.instanceOf(Element)
+    }),
     onSessionEnd: PropTypes.func,
     change: PropTypes.func,
     resources: PropTypes.shape({
@@ -91,7 +94,7 @@ class CheckIn extends React.Component {
       showPickers: false
     };
   }
-  
+
   componentDidMount() {
     this.props.formRef.current = this.props.form;
   }

--- a/src/CheckIn.js
+++ b/src/CheckIn.js
@@ -1,12 +1,13 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Field, reduxForm } from 'redux-form';
+import { Field } from 'react-final-form';
 import {
   FormattedMessage,
   FormattedTime,
   injectIntl,
 } from 'react-intl';
 import moment from 'moment-timezone';
+import stripesFinalForm from '@folio/stripes/final-form';
 import createInactivityTimer from 'inactivity-timer';
 import {
   get,
@@ -76,11 +77,11 @@ class CheckIn extends React.Component {
       }),
     }).isRequired,
     loading: PropTypes.bool.isRequired,
+    form: PropTypes.object.isRequired,
   };
 
   constructor(props) {
     super(props);
-    this.onSubmit = this.onSubmit.bind(this);
     this.showInfo = this.showInfo.bind(this);
     this.renderActions = this.renderActions.bind(this);
     this.handleOptionsChange = this.handleOptionsChange.bind(this);
@@ -89,6 +90,10 @@ class CheckIn extends React.Component {
     this.state = {
       showPickers: false
     };
+  }
+  
+  componentDidMount() {
+    this.props.formRef.current = this.props.form;
   }
 
   componentDidUpdate() {
@@ -135,10 +140,6 @@ class CheckIn extends React.Component {
 
   focusInput() {
     this.props.barcodeRef.current.focus();
-  }
-
-  onSubmit(data) {
-    return this.props.submithandler(data, this);
   }
 
   handleSessionEnd = async () => {
@@ -370,11 +371,17 @@ class CheckIn extends React.Component {
     const {
       handleSubmit,
       intl: { formatDate, formatMessage, formatTime },
+      form,
       scannedItems,
       pristine,
       barcodeRef,
       loading,
     } = this.props;
+
+    const { 
+      hasSubmitErrors = false, 
+      submitErrors = {},
+    } = form.getState();
 
     const { showPickers } = this.state;
     const itemListFormatter = {
@@ -443,7 +450,7 @@ class CheckIn extends React.Component {
     const emptyMessage = !loading ? <FormattedMessage id="ui-checkin.noItems" /> : null;
 
     return (
-      <form onSubmit={handleSubmit(this.onSubmit)}>
+      <form onSubmit={handleSubmit}>
         <div style={containerStyle}>
           <Paneset static>
             <Pane paneTitle={scannedItemsLabel} defaultWidth="100%">
@@ -462,6 +469,7 @@ class CheckIn extends React.Component {
                         component={TextField}
                         data-test-check-in-barcode
                       />
+                      {hasSubmitErrors && <span className={styles.error}>{submitErrors.checkin}</span>}
                     </Layout>
                   </Col>
                   <Col xs={3} sm={1}>
@@ -563,6 +571,6 @@ class CheckIn extends React.Component {
   }
 }
 
-export default reduxForm({
-  form: 'CheckIn',
-})(injectIntl(CheckIn));
+export default stripesFinalForm({
+  navigationCheck: true,
+})(injectIntl(CheckIn));  

--- a/src/Scan.js
+++ b/src/Scan.js
@@ -225,6 +225,8 @@ class Scan extends React.Component {
     if (!item || !item.barcode) {
       return { checkin };
     }
+
+    return {};
   }
 
   onCloseErrorModal = () => {
@@ -236,10 +238,11 @@ class Scan extends React.Component {
   }
 
   tryCheckIn = async (data) => {
+    const submitErrors = {};
     this.checkInData = data;
     const errors = this.validate(data.item);
 
-    if (errors) {
+    if (!isEmpty(errors)) {
       return errors;
     }
 
@@ -250,11 +253,13 @@ class Scan extends React.Component {
       try {
         await this.checkIn();
       } catch (error) {
-        return { checkin: error };
+        submitErrors.checkin = error;
       }
     } else {
       this.setState({ checkedinItem });
     }
+
+    return submitErrors;
   }
 
   checkIn = () => {

--- a/src/checkin.css
+++ b/src/checkin.css
@@ -13,3 +13,7 @@
   height: 1.8em;
   width: 4.5em;
 }
+
+.error {
+  color: var(--error);
+}

--- a/test/bigtest/interactors/check-in.js
+++ b/test/bigtest/interactors/check-in.js
@@ -37,7 +37,7 @@ import WithdrawnModalInteractor from './withdrawn-modal';
   selectPatronDetails = clickable('[data-test-patron-details] a');
   selectItemDetails = clickable('[data-test-item-details] a');
   selectFeeFineDetails = clickable('[data-test-fee-fine-details] a');
-  fillOutError = text('[data-test-check-in-scan] [class^="feedbackError"]');
+  fillOutError = text('[data-test-check-in-scan] [class^="error"]');
   barcodePresent = isPresent('[data-test-check-in-barcode]');
   barcodeInputValue = value('[data-test-check-in-barcode]');
   barcodeInputIsFocused = isPresent('[data-test-check-in-barcode]:focus');


### PR DESCRIPTION
# Purpose
Replace redux-form with react final form.

# Link
https://issues.folio.org/browse/UICHKIN-157

# Approach
Main challenges were in migration submit validation errors, because in redux-form we could throw an redux exception form any method, and in final form we should return an object with error from onSubmit callback. One more problem was in change and reset form methods which available only in form component but called from parent component. In order to fix it I've passed additional ref to Checkin component in order to save link to form object.