### PR TITLE
don't lookup empty values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 * Clear Check In Page When Session Expires. Refs UICHCKIN-177.
 * Add support for checking in Claimed returned items. Refs UICHKIN-116.
 * Add link to request details in action menu. Refs UICHKIN-103.
+* Don't lookup undefined country value (cleans up testing output).
 
 ## [2.0.0] (https://github.com/folio-org/ui-checkin/tree/v2.0.0) (2019-03-13)
 [Full Changelog](https://github.com/folio-org/ui-checkin/compare/v1.10.0...v2.0.0)

--- a/src/util.js
+++ b/src/util.js
@@ -24,7 +24,9 @@ export function convertToSlipData(source = {}, intl, timeZone, locale, slipName 
     'requester.middleName': requester.middleName,
     'requester.addressLine1': requester.addressLine1,
     'requester.addressLine2': requester.addressLine2,
-    'requester.country': intl.formatMessage({ id: `stripes-components.countries.${requester.countryId}` }),
+    'requester.country': requester.country
+      ? intl.formatMessage({ id: `stripes-components.countries.${requester.countryId}` })
+      : '',
     'requester.city': requester.city,
     'requester.stateProvRegion': requester.region,
     'requester.zipPostalCode': requester.postalCode,


### PR DESCRIPTION
If `requester.country` is undefined, don't attempt to retrieve its
translated value because obviously that will fail. `react-intl` throws a
very noisy warning about undefined values and this really pollutes the
test output.