### PR TITLE
UICHKIN-185: Checkin barcode CQL injection

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ yarn.lock
 .DS_Store
 yarn-error.log
 artifacts
+.npmrc
+stripes.config.js.local

--- a/src/Scan.js
+++ b/src/Scan.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import SafeHTMLMessage from '@folio/react-intl-safe-html';
+import { escapeCqlValue } from '@folio/stripes/util';
 import {
   FormattedMessage,
   injectIntl,
@@ -249,8 +250,7 @@ class Scan extends React.Component {
     if (!isEmpty(errors)) {
       return errors;
     }
-
-    const { item: { barcode } } = data;
+    const barcode = '"' + escapeCqlValue(data.item.barcode) + '"';
     const checkedinItem = await this.fetchItem(barcode);
 
     if (!checkedinItem) {


### PR DESCRIPTION
I modified the checkin submission function to use
the "escapeCqlValue" function to properly escape
characters and added quotation marks to the value.
The error referenced no longer appears, instead
you get a modal telling you the value could not be
found.

Refs: https://issues.folio.org/browse/UICHKIN-185