### PR TITLE
Refactor to MirageJS

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,7 +63,6 @@
   },
   "devDependencies": {
     "@bigtest/interactor": "^0.7.0",
-    "@bigtest/mirage": "^0.0.1",
     "@bigtest/mocha": "^0.5.0",
     "@bigtest/react": "^0.1.2",
     "@folio/eslint-config-stripes": "^5.1.0",

--- a/package.json
+++ b/package.json
@@ -75,6 +75,9 @@
     "core-js": "^3.6.4",
     "eslint": "^6.2.1",
     "eslint-plugin-no-only-tests": "^2.4.0",
+    "faker": "^4.1.0",
+    "inflected": "^2.0.4",
+    "miragejs": "^0.1.40",
     "mocha": "^5.2.0",
     "react": "^16.4.1",
     "react-dom": "^16.4.1",
@@ -89,16 +92,16 @@
   "dependencies": {
     "@folio/react-intl-safe-html": "^2.0.0",
     "dateformat": "^2.0.0",
+    "final-form": "^4.19.1",
     "html-to-react": "^1.3.3",
     "inactivity-timer": "^1.0.0",
     "lodash": "^4.17.4",
     "moment-timezone": "^0.5.14",
     "prop-types": "^15.6.0",
     "react-barcode": "^1.3.2",
+    "react-final-form": "^6.4.0",
     "react-hot-loader": "^4.3.12",
-    "react-to-print": "^2.3.2",
-    "final-form": "^4.19.1",
-    "react-final-form": "^6.4.0"
+    "react-to-print": "^2.3.2"
   },
   "peerDependencies": {
     "@folio/stripes": "^4.0.0",

--- a/test/bigtest/helpers/setup-application.js
+++ b/test/bigtest/helpers/setup-application.js
@@ -5,7 +5,10 @@ export default function setupApplication({
   scenarios = ['default'],
 } = {}) {
   setupStripesCore({
-    mirageOptions,
+    mirageOptions: {
+      serverType: 'miragejs',
+      ...mirageOptions
+    },
     scenarios,
     currentUser: {
       curServicePoint: { id: 1 },

--- a/test/bigtest/network/factories/item.js
+++ b/test/bigtest/network/factories/item.js
@@ -1,4 +1,5 @@
-import { Factory, faker, trait } from '@bigtest/mirage';
+import { Factory } from 'miragejs';
+import faker from 'faker';
 
 export default Factory.extend({
   title: () => faker.company.catchPhrase(),
@@ -19,11 +20,14 @@ export default Factory.extend({
     return { name: faker.random.word() };
   },
 
-  withLoan: trait({
-    afterCreate(item, server) {
-      server.create('loan', 'withUser', {
-        item
-      });
-    }
-  })
+  withLoan: {
+    extension: {
+      afterCreate(item, server) {
+        server.create('loan', 'withUser', {
+          item
+        });
+      }
+    },
+    __isTrait__: true
+  }
 });

--- a/test/bigtest/network/factories/loan.js
+++ b/test/bigtest/network/factories/loan.js
@@ -1,4 +1,5 @@
-import { Factory, faker, trait } from '@bigtest/mirage';
+import { Factory } from 'miragejs';
+import faker from 'faker';
 
 export default Factory.extend({
   systemReturnDate: () => faker.date.recent().toISOString(),
@@ -10,11 +11,14 @@ export default Factory.extend({
   checkinServicePointId: () => faker.random.uuid(),
   status: () => 'Closed',
 
-  withUser: trait({
-    afterCreate(loan, server) {
-      const user = server.create('user');
-      loan.user = user;
-      loan.save();
-    }
-  })
+  withUser: {
+    extension: {
+      afterCreate(loan, server) {
+        const user = server.create('user');
+        loan.user = user;
+        loan.save();
+      }
+    },
+    __isTrait__: true
+  }
 });

--- a/test/bigtest/network/factories/request.js
+++ b/test/bigtest/network/factories/request.js
@@ -1,4 +1,5 @@
-import { Factory, faker, trait } from '@bigtest/mirage';
+import { Factory } from 'miragejs';
+import faker from 'faker';
 
 export default Factory.extend({
   id: () => faker.random.uuid(),
@@ -14,10 +15,13 @@ export default Factory.extend({
     middleName : faker.name.firstName(),
     barcode : Math.floor(Math.random() * 9000000000000) + 1000000000000,
   }),
-  withItem: trait({
-    afterCreate(request, server) {
-      const item = server.create('item');
-      item.save();
-    }
-  })
+  withItem: {
+    extension: {
+      afterCreate(request, server) {
+        const item = server.create('item');
+        item.save();
+      }
+    },
+    __isTrait__: true
+  }
 });

--- a/test/bigtest/network/factories/service-point.js
+++ b/test/bigtest/network/factories/service-point.js
@@ -1,4 +1,5 @@
-import { Factory, faker } from '@bigtest/mirage';
+import { Factory } from 'miragejs';
+import faker from 'faker';
 
 export default Factory.extend({
   name: faker.company.catchPhrase(),

--- a/test/bigtest/network/factories/staff-slip.js
+++ b/test/bigtest/network/factories/staff-slip.js
@@ -1,4 +1,5 @@
-import { Factory, faker } from '@bigtest/mirage';
+import { Factory } from 'miragejs';
+import faker from 'faker';
 
 export default Factory.extend({
   id: faker.random.uuid,

--- a/test/bigtest/network/factories/user.js
+++ b/test/bigtest/network/factories/user.js
@@ -1,4 +1,5 @@
-import { Factory, faker } from '@bigtest/mirage';
+import { Factory } from 'miragejs';
+import faker from 'faker';
 
 export default Factory.extend({
   username: () => faker.internet.userName()

--- a/test/bigtest/network/index.js
+++ b/test/bigtest/network/index.js
@@ -1,4 +1,3 @@
-// import { camelize } from '@bigtest/mirage';
 import { camelize, underscore } from 'inflected';
 
 // auto-import all mirage submodules

--- a/test/bigtest/network/index.js
+++ b/test/bigtest/network/index.js
@@ -1,4 +1,5 @@
-import { camelize } from '@bigtest/mirage';
+// import { camelize } from '@bigtest/mirage';
+import { camelize, underscore } from 'inflected';
 
 // auto-import all mirage submodules
 const req = require.context('./', true, /\.js$/);
@@ -8,7 +9,7 @@ const modules = req.keys().reduce((acc, modulePath) => {
   const moduleName = moduleParts[2];
 
   if (moduleName) {
-    const moduleKey = camelize(moduleName.replace('.js', ''));
+    const moduleKey = camelize(underscore(moduleName.replace('.js', '')), false);
 
     return Object.assign(acc, {
       [moduleType]: {

--- a/test/bigtest/network/models/item.js
+++ b/test/bigtest/network/models/item.js
@@ -1,3 +1,3 @@
-import { Model } from '@bigtest/mirage';
+import { Model } from 'miragejs';
 
 export default Model.extend();

--- a/test/bigtest/network/models/loan.js
+++ b/test/bigtest/network/models/loan.js
@@ -1,4 +1,4 @@
-import { Model, belongsTo } from '@bigtest/mirage';
+import { Model, belongsTo } from 'miragejs';
 
 export default Model.extend({
   item: belongsTo(),

--- a/test/bigtest/network/models/request.js
+++ b/test/bigtest/network/models/request.js
@@ -1,3 +1,3 @@
-import { Model } from '@bigtest/mirage';
+import { Model } from 'miragejs';
 
 export default Model.extend();

--- a/test/bigtest/network/models/service-point.js
+++ b/test/bigtest/network/models/service-point.js
@@ -1,3 +1,3 @@
-import { Model } from '@bigtest/mirage';
+import { Model } from 'miragejs';
 
 export default Model.extend();

--- a/test/bigtest/network/models/staff-slip.js
+++ b/test/bigtest/network/models/staff-slip.js
@@ -1,3 +1,3 @@
-import { Model } from '@bigtest/mirage';
+import { Model } from 'miragejs';
 
 export default Model.extend();

--- a/test/bigtest/network/models/user.js
+++ b/test/bigtest/network/models/user.js
@@ -1,3 +1,3 @@
-import { Model } from '@bigtest/mirage';
+import { Model } from 'miragejs';
 
 export default Model.extend();

--- a/test/bigtest/network/serializers/application.js
+++ b/test/bigtest/network/serializers/application.js
@@ -1,3 +1,3 @@
-import { RestSerializer } from '@bigtest/mirage';
+import { RestSerializer } from 'miragejs';
 
 export default RestSerializer;

--- a/test/bigtest/network/serializers/okapi.js
+++ b/test/bigtest/network/serializers/okapi.js
@@ -1,10 +1,10 @@
-import { camelize, pluralize } from '@bigtest/mirage';
+import { pluralize, underscore, camelize } from 'inflected';
 import ApplicationSerializer from './application';
 
 export default ApplicationSerializer.extend({
   serialize(...args) {
     const { modelName } = args[0];
-    const collectionName = pluralize(camelize(modelName));
+    const collectionName = pluralize(camelize(underscore(modelName), false));
     const name = this.name || collectionName;
     const json = ApplicationSerializer.prototype.serialize.apply(this, args);
     const data = json[collectionName];

--- a/test/bigtest/tests/check-in-test.js
+++ b/test/bigtest/tests/check-in-test.js
@@ -4,10 +4,8 @@ import {
   it,
 } from '@bigtest/mocha';
 import { expect } from 'chai';
-import {
-  Response,
-  faker,
-} from '@bigtest/mirage';
+import { Response } from 'miragejs';
+import faker from 'faker';
 
 import setupApplication from '../helpers/setup-application';
 import CheckInInteractor from '../interactors/check-in';


### PR DESCRIPTION
## Motivation
`@bigtest/mirage` was originally a prototype to make `mirage` available to any framework, but it has since been archived in favor of `miragejs`. This is the first of many refactoring I will be doing in order to completely migrate all of `folio-org` projects from `@bigtest/mirage` to `miragejs`.

## Approach
- Removed `@bigtest/mirage` and added `inflected`, `faker`, and `miragejs` as dev dependencies.
- Configured `miragejs` as the server type for `setupStripesCore()`.
- Ran tests after the refactor to confirm they all pass.