### PR TITLE
UICHKIN-164: Add Aged to lost modal when item checked in

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,8 @@
 * Refactor from `bigtest/mirage` to `miragejs`.
 * Increment `@folio/stripes` to `v5`, `react-router` to `v5.2`.
 * Only show fees/fines for checkin items when loan ID matches. Fixes UICHKIN-183.
-* Fix {{requester.country}} token not populating in delivery staff slip. UICHKIN-190
+* Fix {{requester.country}} token not populating in delivery staff slip. Fixes UICHKIN-190.
+* Show confirmation modal when an item with the status `Aged to lost` is checked in. Refs UICHKIN-164.
 
 ## [3.0.0] (https://github.com/folio-org/ui-checkin/tree/v3.0.0) (2020-06-11)
 [Full Changelog](https://github.com/folio-org/ui-checkin/compare/v2.0.1...v3.0.0)

--- a/src/ModalManager.js
+++ b/src/ModalManager.js
@@ -88,6 +88,7 @@ class ModalManager extends React.Component {
       statuses.DECLARED_LOST,
       statuses.MISSING,
       statuses.LOST_AND_PAID,
+      statuses.AGED_TO_LOST,
     ], checkedinItem?.status?.name);
   }
 

--- a/src/consts.js
+++ b/src/consts.js
@@ -8,6 +8,7 @@ const statuses = {
   DECLARED_LOST: 'Declared lost',
   WITHDRAWN: 'Withdrawn',
   LOST_AND_PAID: 'Lost and paid',
+  AGED_TO_LOST: 'Aged to lost',
 };
 
 const statusMessages = {
@@ -15,6 +16,7 @@ const statusMessages = {
   'Declared lost': 'ui-checkin.statuses.declaredLost',
   'Withdrawn': 'ui-checkin.statuses.withdrawn',
   'Lost and paid': 'ui-checkin.statuses.lostAndPaid',
+  'Aged to lost': 'ui-checkin.statuses.agedToLost',
 };
 
 const requestTypes = {

--- a/test/bigtest/tests/check-in-test.js
+++ b/test/bigtest/tests/check-in-test.js
@@ -15,6 +15,7 @@ const statuses = [
   'Declared lost',
   'Withdrawn',
   'Lost and paid',
+  'Aged to lost',
 ];
 
 describe('CheckIn', () => {

--- a/translations/ui-checkin/en.json
+++ b/translations/ui-checkin/en.json
@@ -88,5 +88,6 @@
   "statuses.missing": "Missing",
   "statuses.declaredLost": "'Declared lost",
   "statuses.withdrawn": "Withdrawn",
-  "statuses.lostAndPaid": "Lost and paid"
+  "statuses.lostAndPaid": "Lost and paid",
+  "statuses.agedToLost": "Aged to lost"
 }


### PR DESCRIPTION
https://issues.folio.org/browse/UICHKIN-164

## Purpose
Ask the user to confirm check in when an item with the status Aged to lost is checked in.

### Screenshot
![Screen Shot 2020-08-19 at 17 49 51](https://user-images.githubusercontent.com/49517355/90651605-df962000-e245-11ea-8da3-203be0650eee.png)