### PR TITLE
UICHKIN-193 html-encode strings for react-to-print

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Refactor from `bigtest/mirage` to `miragejs`.
 * Increment `@folio/stripes` to `v5`, `react-router` to `v5.2`.
 * Only show fees/fines for checkin items when loan ID matches. Fixes UICHKIN-183.
+* Fix {{requester.country}} token not populating in delivery staff slip. UICHKIN-190
 
 ## [3.0.0] (https://github.com/folio-org/ui-checkin/tree/v3.0.0) (2020-06-11)
 [Full Changelog](https://github.com/folio-org/ui-checkin/compare/v2.0.1...v3.0.0)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,8 @@
 * Refactor from `bigtest/mirage` to `miragejs`.
 * Increment `@folio/stripes` to `v5`, `react-router` to `v5.2`.
 * Only show fees/fines for checkin items when loan ID matches. Fixes UICHKIN-183.
-* Fix {{requester.country}} token not populating in delivery staff slip. UICHKIN-190
+* Fix `{{requester.country}}` token not populating in delivery staff slip. UICHKIN-190.
+* Escape values passed to `react-to-print`. Fixes UICHKIN-193.
 
 ## [3.0.0] (https://github.com/folio-org/ui-checkin/tree/v3.0.0) (2020-06-11)
 [Full Changelog](https://github.com/folio-org/ui-checkin/compare/v2.0.1...v3.0.0)

--- a/package.json
+++ b/package.json
@@ -91,7 +91,6 @@
   "dependencies": {
     "@folio/react-intl-safe-html": "^2.0.0",
     "dateformat": "^2.0.0",
-    "entities": "^2.0.0",
     "final-form": "^4.19.1",
     "html-to-react": "^1.3.3",
     "inactivity-timer": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -91,6 +91,7 @@
   "dependencies": {
     "@folio/react-intl-safe-html": "^2.0.0",
     "dateformat": "^2.0.0",
+    "entities": "^2.0.0",
     "final-form": "^4.19.1",
     "html-to-react": "^1.3.3",
     "inactivity-timer": "^1.0.0",

--- a/src/util.js
+++ b/src/util.js
@@ -24,7 +24,7 @@ export function convertToSlipData(source = {}, intl, timeZone, locale, slipName 
     'requester.middleName': requester.middleName,
     'requester.addressLine1': requester.addressLine1,
     'requester.addressLine2': requester.addressLine2,
-    'requester.country': requester.country
+    'requester.country': requester.countryId
       ? intl.formatMessage({ id: `stripes-components.countries.${requester.countryId}` })
       : '',
     'requester.city': requester.city,

--- a/src/util.js
+++ b/src/util.js
@@ -1,12 +1,11 @@
 import moment from 'moment-timezone';
-import { get } from 'lodash';
-import { encodeHTML } from 'entities';
+import { get, escape } from 'lodash';
 
 export function buildTemplate(str) {
   return o => {
     return str.replace(/{{([^{}]*)}}/g, (a, b) => {
       const r = o[b];
-      return typeof r === 'string' || typeof r === 'number' ? encodeHTML(r) : '';
+      return typeof r === 'string' || typeof r === 'number' ? escape(r) : '';
     });
   };
 }

--- a/src/util.js
+++ b/src/util.js
@@ -1,11 +1,12 @@
 import moment from 'moment-timezone';
 import { get } from 'lodash';
+import { encodeHTML } from 'entities';
 
 export function buildTemplate(str) {
   return o => {
     return str.replace(/{{([^{}]*)}}/g, (a, b) => {
       const r = o[b];
-      return typeof r === 'string' || typeof r === 'number' ? r : '';
+      return typeof r === 'string' || typeof r === 'number' ? encodeHTML(r) : '';
     });
   };
 }


### PR DESCRIPTION
Values passed to `react-to-print` need to be escaped because of the way
it generates its document under the hood. Without escaping, if we passed
a value like `something<bad>very bad`, this would cause React to blow up
when slips were generated with an error like
```
ERROR:Failed to execute 'createElement' on 'Document':The tag name
provided ('bad') is not a valid name.
```

Refs [UICHKIN-193](https://issues.folio.org/browse/UICHKIN-193)