### PR TITLE
UICHKIN-195 handle malformed timestamps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * Fix `{{requester.country}}` token not populating in delivery staff slip. Fixes UICHKIN-190.
 * Show confirmation modal when an item with the status `Aged to lost` is checked in. Refs UICHKIN-164.
 * Escape values passed to `react-to-print`. Fixes UICHKIN-193.
+* Handle malformed timestamps. Refs UICHKIN-195.
 
 ## [3.0.0] (https://github.com/folio-org/ui-checkin/tree/v3.0.0) (2020-06-11)
 [Full Changelog](https://github.com/folio-org/ui-checkin/compare/v2.0.1...v3.0.0)

--- a/src/CheckIn.js
+++ b/src/CheckIn.js
@@ -3,7 +3,6 @@ import PropTypes from 'prop-types';
 import { Field } from 'react-final-form';
 import {
   FormattedMessage,
-  FormattedTime,
   injectIntl,
 } from 'react-intl';
 import moment from 'moment-timezone';
@@ -32,6 +31,7 @@ import {
   DropdownMenu,
   Tooltip,
   Dropdown,
+  FormattedTime,
 } from '@folio/stripes/components';
 import { effectiveCallNumber } from '@folio/stripes/util';
 import { IfPermission } from '@folio/stripes/core';

--- a/src/ModalManager.js
+++ b/src/ModalManager.js
@@ -10,10 +10,12 @@ import SafeHTMLMessage from '@folio/react-intl-safe-html';
 import {
   FormattedMessage,
   injectIntl,
+} from 'react-intl';
+import {
+  ConfirmationModal,
   FormattedDate,
   FormattedTime,
-} from 'react-intl';
-import { ConfirmationModal } from '@folio/stripes/components';
+} from '@folio/stripes/components';
 
 import CheckinNoteModal from './components/CheckinNoteModal';
 import ClaimedReturnedModal from './components/ClaimedReturnedModal';


### PR DESCRIPTION
Use the stripes-components versions of `<FormattedDate>` and
`<FormattedTime>` because they do not choke on the timestamps that are
provided by some backend modules.

Refs [UICHKIN-195](https://issues.folio.org/browse/UICHKIN-195), [STCOM-659](https://issues.folio.org/browse/STCOM-659)