### PR TITLE
UICHKIN-198: Update tooltip placement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 * Show confirmation modal when an item with the status `Aged to lost` is checked in. Refs UICHKIN-164.
 * Escape values passed to `react-to-print`. Fixes UICHKIN-193.
 * Update `react-intl` to `v5.7.0`.
+* Fixed issue where tooltip were rendering on top of the dropdown on the actions button. UICHKIN-198.
 
 ## [3.0.0] (https://github.com/folio-org/ui-checkin/tree/v3.0.0) (2020-06-11)
 [Full Changelog](https://github.com/folio-org/ui-checkin/compare/v2.0.1...v3.0.0)

--- a/src/CheckIn.js
+++ b/src/CheckIn.js
@@ -261,11 +261,13 @@ class CheckIn extends React.Component {
         id={`actions-tooltip-${loan.rowIndex}`}
         text={<FormattedMessage id="ui-checkin.actions.moreDetails" />}
         triggerRef={triggerRef}
+        placement="top"
       >
         {({ ref, ariaIds }) => (
           <IconButton
             {...getTriggerProps()}
             icon="ellipsis"
+            placement="top"
             size="medium"
             aria-labelledby={ariaIds.text}
             id={`available-actions-button-${loan.rowIndex}`}


### PR DESCRIPTION
Fixed issue where tooltip was rendering below the button and on top of the dropdown on the actions menu.

https://issues.folio.org/browse/UICHKIN-198

## Before
![image](https://user-images.githubusercontent.com/640976/92596489-2ce63a00-f2a6-11ea-9007-c254d4dfabc1.png)


## After
![image](https://user-images.githubusercontent.com/640976/92596403-0d4f1180-f2a6-11ea-81e2-f4c91fa8d9dc.png)
