### PR TITLE
UICHKIN-207: Clear state after successful checkin or cancel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change history for ui-checkin
 
+## [4.1.0] In Progress
+
+* Clear `checkinNotesMode` after succesful checkout or cancel. Fixes UICHKIN-207.
+
 ## [4.0.0] (https://github.com/folio-org/ui-checkin/tree/v4.0.0) (2020-10-08)
 [Full Changelog](https://github.com/folio-org/ui-checkin/compare/v3.0.0...v4.0.0)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## [4.1.0] In Progress
 
-* Clear `checkinNotesMode` after succesful checkout or cancel. Fixes UICHKIN-207.
+* Clear `checkinNotesMode` after succesful checkin or cancel. Fixes UICHKIN-207.
 
 ## [4.0.0] (https://github.com/folio-org/ui-checkin/tree/v4.0.0) (2020-10-08)
 [Full Changelog](https://github.com/folio-org/ui-checkin/compare/v3.0.0...v4.0.0)

--- a/src/Scan.js
+++ b/src/Scan.js
@@ -338,6 +338,7 @@ class Scan extends React.Component {
     this.setState({
       checkedinItem: null,
       loading: false,
+      checkinNotesMode: false,
     }, this.setFocusInput);
   }
 
@@ -635,6 +636,7 @@ class Scan extends React.Component {
 
   onCancel = () => {
     this.clearForm();
+    this.processCheckInDone();
   };
 
   showCheckinNotes = (loan) => {


### PR DESCRIPTION
https://issues.folio.org/browse/UICHKIN-207

The `checkinNotesMode` was left set to `true` in some cases which caused issues when more than one item was check-in.