### PR TITLE
UICHKIN-208: Display patron comments in <ConfirmStatusModal>

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * `Timepicker` defaults to local time. Refs UICHKIN-206.
 * `Timepicker` defaults to tenant's time. Fixes UICHKIN-206.
 * Fix typo in status label. Fixes UICHKIN-211.
+* Display patron notes in `<ConfirmStatusModal>`. Refs UICHKIN-208.
 
 ## [4.0.0] (https://github.com/folio-org/ui-checkin/tree/v4.0.0) (2020-10-08)
 [Full Changelog](https://github.com/folio-org/ui-checkin/compare/v3.0.0...v4.0.0)

--- a/src/Scan.js
+++ b/src/Scan.js
@@ -479,9 +479,12 @@ class Scan extends React.Component {
       },
     } = this.props;
 
-    const { item = {} } = request;
+    const {
+      item = {},
+      patronComments,
+    } = request;
     const slipData = convertToSlipData(staffSlipContext, intl, timezone, locale);
-    const message = (
+    const messages = [
       <SafeHTMLMessage
         id="ui-checkin.statusModal.hold.message"
         values={{
@@ -491,7 +494,19 @@ class Scan extends React.Component {
           pickupServicePoint: get(request, 'pickupServicePoint.name', '')
         }}
       />
-    );
+    ];
+
+    if (patronComments) {
+      messages.push(
+        <FormattedMessage
+          id="ui-checkin.statusModal.hold.comment"
+          values={{
+            comment: patronComments,
+            strong: (chunks) => <strong>{chunks}</strong>,
+          }}
+        />
+      );
+    }
 
     return (
       <ConfirmStatusModal
@@ -502,7 +517,7 @@ class Scan extends React.Component {
         isPrintable={this.isPrintable('hold')}
         slipData={slipData}
         label={<FormattedMessage id="ui-checkin.statusModal.hold.heading" />}
-        message={message}
+        message={messages}
       />
     );
   }

--- a/src/Scan.js
+++ b/src/Scan.js
@@ -585,7 +585,7 @@ class Scan extends React.Component {
     const slipData = convertToSlipData(staffSlipContext, intl, timezone, locale, 'Transit');
 
     const destinationServicePoint = get(item, 'inTransitDestinationServicePoint.name', '');
-    const message = (
+    const messages = [
       <SafeHTMLMessage
         id="ui-checkin.statusModal.transit.message"
         values={{
@@ -595,7 +595,7 @@ class Scan extends React.Component {
           servicePoint: destinationServicePoint
         }}
       />
-    );
+    ];
 
     return (
       <ConfirmStatusModal
@@ -604,7 +604,7 @@ class Scan extends React.Component {
         slipData={slipData}
         isPrintable={this.isPrintable('transit')}
         label={<FormattedMessage id="ui-checkin.statusModal.transit.heading" />}
-        message={message}
+        message={messages}
         onConfirm={this.onModalClose}
         onCancel={this.handleOnAfterPrint}
       />

--- a/src/components/ConfirmStatusModal/ConfirmStatusModal.js
+++ b/src/components/ConfirmStatusModal/ConfirmStatusModal.js
@@ -75,6 +75,7 @@ class ConfirmStatusModal extends React.Component {
           </Button>}
       </div>
     );
+    const messageParts = message.map(m => <p>{m}</p>);
 
     return (
       <Modal
@@ -88,7 +89,7 @@ class ConfirmStatusModal extends React.Component {
         size="small"
         footer={footer}
       >
-        <p>{message}</p>
+        {messageParts}
         <Row>
           <Col xs>
             <Checkbox

--- a/translations/ui-checkin/en.json
+++ b/translations/ui-checkin/en.json
@@ -63,6 +63,7 @@
   "statusModal.delivery.closeAndCheckout": "Close and check out",
   "statusModal.delivery.message": "There is a delivery request for <strong>{itemTitle} ({itemType})</strong> (Barcode: {itemBarcode}). <strong>Please check the item out and route for delivery.</strong>",
   "statusModal.hold.message": "Place <strong>{title} ({materialType})</strong> (Barcode: {barcode}) on Hold Shelf at <strong>{pickupServicePoint}</strong> for request.",
+  "statusModal.hold.comment": "<strong>Patron comments:</strong> {comment}",
   "statusModal.printSlip": "Print slip",
   "unknownError": "Unknown error occurred",
   "multipieceModal.confirm": "Confirm",

--- a/translations/ui-checkin/en_US.json
+++ b/translations/ui-checkin/en_US.json
@@ -31,6 +31,7 @@
     "statusModal.transit.message": "Route <strong>{title} ({materialType})</strong> (Barcode: {barcode}) to <strong>{servicePoint}</strong>.",
     "statusModal.hold.heading": "Awaiting pickup for a request",
     "statusModal.hold.message": "Place <strong>{title} ({materialType})</strong> (Barcode: {barcode}) on Hold Shelf at <strong>{pickupServicePoint}</strong> for request.",
+    "statusModal.hold.comment": "<strong>Patron comments:</strong> {comment}",
     "scannedItems": "Scanned Items",
     "statusModal.printSlip": "Print slip",
     "unknownError": "Unknown error occurred",


### PR DESCRIPTION
https://issues.folio.org/browse/UICHKIN-208

This adds a second line to the `<ConfirmStatusModal>` message with the request record's patron comment, if there is one.

<img width="564" alt="Screen Shot 2020-12-03 at 4 07 09 PM" src="https://user-images.githubusercontent.com/1322242/101094488-7df68900-358a-11eb-9974-de05214ab32a.png">
