### PR TITLE
UICHKIN-220 - Barcode image not rendering on staff slips - fails gracefully

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * `Timepicker` defaults to tenant's time. Fixes UICHKIN-206.
 * Fix typo in status label. Fixes UICHKIN-211.
 * Display patron notes in `<ConfirmStatusModal>`. Refs UICHKIN-208.
+* Barcode image not rendering on staff slips. Refs UICHKIN-220.
 
 ## [4.0.0] (https://github.com/folio-org/ui-checkin/tree/v4.0.0) (2020-10-08)
 [Full Changelog](https://github.com/folio-org/ui-checkin/compare/v3.0.0...v4.0.0)

--- a/src/util.js
+++ b/src/util.js
@@ -1,7 +1,7 @@
 import moment from 'moment-timezone';
 import { escape } from 'lodash';
 
-const escapeValue = (val) => {
+export const escapeValue = (val) => {
   if (val.startsWith('<Barcode>') && val.endsWith('</Barcode>')) {
     return val;
   }

--- a/src/util.js
+++ b/src/util.js
@@ -1,11 +1,19 @@
 import moment from 'moment-timezone';
 import { escape } from 'lodash';
 
+const escapeValue = (val) => {
+  if (val.startsWith('<Barcode>') && val.endsWith('</Barcode>')) {
+    return val;
+  }
+
+  return escape(val);
+};
+
 export function buildTemplate(str) {
   return o => {
     return str.replace(/{{([^{}]*)}}/g, (a, b) => {
       const r = o[b];
-      return typeof r === 'string' || typeof r === 'number' ? escape(r) : '';
+      return typeof r === 'string' || typeof r === 'number' ? escapeValue(r) : '';
     });
   };
 }

--- a/test/bigtest/tests/util-test.js
+++ b/test/bigtest/tests/util-test.js
@@ -2,7 +2,10 @@ import { describe, it } from '@bigtest/mocha';
 import { expect } from 'chai';
 
 import setupApplication from '../helpers/setup-application';
-import { getCheckinSettings } from '../../../src/util';
+import {
+  escapeValue,
+  getCheckinSettings,
+} from '../../../src/util';
 
 describe('Utility functions', () => {
   setupApplication();
@@ -16,6 +19,21 @@ describe('Utility functions', () => {
     });
     it('returns an empty object if there\'s an error', () => {
       expect(getCheckinSettings([{ value:'' }])).to.deep.equal({});
+    });
+  });
+
+  describe('escape value util', () => {
+    it('should return Barcode tag', () => {
+      const barcodeVal = '<Barcode>123456</Barcode>';
+
+      expect(escapeValue(barcodeVal)).to.equal(barcodeVal);
+    });
+
+    it('should return escaped values for non Barcode values', () => {
+      const passedValue = 'something<bad>very bad';
+      const expectedValue = 'something&lt;bad&gt;very bad';
+
+      expect(escapeValue(passedValue)).to.equal(expectedValue);
     });
   });
 });


### PR DESCRIPTION
# Purpose
Fix `<Barcode>` tag processing caused by fix https://github.com/folio-org/ui-checkin/pull/341

# Link
https://issues.folio.org/browse/UICHKIN-220

# Screenshot
<img width="1678" alt="Screen Shot 2020-12-08 at 10 22 50" src="https://user-images.githubusercontent.com/43472449/101458272-595e3080-393f-11eb-967b-16901855223a.png">
