### PR TITLE
UICHKIN-211: Fix en_US translation

### DIFF
--- a/translations/ui-checkin/en_US.json
+++ b/translations/ui-checkin/en_US.json
@@ -85,7 +85,7 @@
     "confirmModal.confirm": "Confirm",
     "confirmModal.cancel": "Cancel",
     "statuses.missing": "Missing",
-    "statuses.declaredLost": "'Declared lost",
+    "statuses.declaredLost": "Declared lost",
     "statuses.withdrawn": "Withdrawn",
     "statuses.lostAndPaid": "Lost and paid",
     "feesFinesOwed": "(fees/fines owed)",


### PR DESCRIPTION
Weirdly, _only_ the en_US translation file failed to pick up the apostrophe removal for UICHKIN-211.