### PR TITLE
UICHKIN-210: Prevent check in for intellectual item status

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 * Display patron notes in `<ConfirmStatusModal>`. Refs UICHKIN-208.
 * Barcode image not rendering on staff slips. Refs UICHKIN-220.
 * Check in items with Restricted status. Refs UICHKIN-221.
+* Prevent check in when item with intellectual item status is scanned. Refs UICHKIN-210.
 
 ## [4.0.0] (https://github.com/folio-org/ui-checkin/tree/v4.0.0) (2020-10-08)
 [Full Changelog](https://github.com/folio-org/ui-checkin/compare/v3.0.0...v4.0.0)

--- a/src/Scan.js
+++ b/src/Scan.js
@@ -235,7 +235,7 @@ class Scan extends React.Component {
   }
 
   onCloseErrorModal = () => {
-    this.setState({ itemError: false },
+    this.setState({ itemError: null },
       () => {
         this.clearField('item.barcode');
         this.setFocusInput();
@@ -351,6 +351,7 @@ class Scan extends React.Component {
     errors: [
       {
         parameters,
+        message,
       } = {},
     ] = [],
   }) {
@@ -360,6 +361,7 @@ class Scan extends React.Component {
         _error: 'unknownError',
       }
       : {
+        message,
         barcode: parameters[0].value,
         _error: parameters[0].key,
       };
@@ -611,15 +613,22 @@ class Scan extends React.Component {
     );
   }
 
-  renderErrorModal(error) {
-    const message = (
-      <SafeHTMLMessage
-        id="ui-checkin.errorModal.noItemFound"
-        values={{
-          barcode: error.barcode,
-        }}
-      />
-    );
+  renderErrorModal({ message, barcode }) {
+    let errorMessage;
+    let label;
+
+    if (message === `No item with barcode ${barcode} exists`) {
+      errorMessage = (
+        <SafeHTMLMessage
+          id="ui-checkin.errorModal.noItemFound"
+          values={{ barcode }}
+        />
+      );
+      label = <FormattedMessage id="ui-checkin.itemNotFound" />;
+    } else {
+      errorMessage = message;
+      label = <FormattedMessage id="ui-checkin.itemNotCheckedIn" />;
+    }
 
     const footer = (
       <ModalFooter>
@@ -636,16 +645,12 @@ class Scan extends React.Component {
       <Modal
         open
         size="small"
-        label={
-          <FormattedMessage
-            id="ui-checkin.itemNotFound"
-          />
-}
+        label={label}
         footer={footer}
         dismissible
         onClose={this.onCloseErrorModal}
       >
-        {message}
+        {errorMessage}
       </Modal>
     );
   }

--- a/translations/ui-checkin/en.json
+++ b/translations/ui-checkin/en.json
@@ -29,6 +29,7 @@
   "feeFineDetails": "Fee/fine details",
   "newFeeFine": "New Fee/Fine",
   "itemNotFound": "Item not found",
+  "itemNotCheckedIn": "Item not checked in",
   "patronDetails": "Patron details",
   "loanNoExist": "Loan does not exist",
   "itemNoExist": "Item with this barcode does not exist",


### PR DESCRIPTION
https://issues.folio.org/browse/UICHKIN-210

### Purpose
Added display of the `ErrorModal` when trying to check in an item with the `Intellectual item` status.

### Screenshot
![Screen Shot 2021-01-11 at 16 05 11](https://user-images.githubusercontent.com/49517355/104192088-06d4d000-5427-11eb-8c6f-0f0d2aad31e9.png)