### PR TITLE
UICHKIN-120: Add confirmation modal for 4 new item statuses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 * Update to stripes v6. Refs UICHKIN-226.
 * Fix incorrect ref assignment. Refs UICHKIN-205.
 * Increment `@folio/stripes-cli` to `v2`. Refs UICHKIN-231.
+* Show confirmation modal when check in an item with one of the new statuses (Long missing, In process (non-requestable), Unavailable, Unknown). Refs UICHKIN-120.
 
 ## [4.0.0] (https://github.com/folio-org/ui-checkin/tree/v4.0.0) (2020-10-08)
 [Full Changelog](https://github.com/folio-org/ui-checkin/compare/v3.0.0...v4.0.0)

--- a/src/ModalManager.js
+++ b/src/ModalManager.js
@@ -1,8 +1,8 @@
 import {
   get,
   orderBy,
+  lowerFirst,
   upperFirst,
-  includes,
 } from 'lodash';
 import React from 'react';
 import PropTypes from 'prop-types';
@@ -26,6 +26,7 @@ import {
   statuses,
   statusMessages,
 } from './consts';
+import { shouldConfirmStatusModalBeShown } from './util';
 
 import css from './ModalManager.css';
 
@@ -50,7 +51,7 @@ class ModalManager extends React.Component {
         exec: () => this.setState({ showClaimedReturnedModal: true }),
       },
       {
-        validate: this.shouldConfirmStatusModalBeShown,
+        validate: () => shouldConfirmStatusModalBeShown(this.state.checkedinItem),
         exec: () => this.setState({ showConfirmModal: true }),
       },
       {
@@ -81,19 +82,6 @@ class ModalManager extends React.Component {
     }
 
     return this.props.onDone();
-  }
-
-  shouldConfirmStatusModalBeShown = () => {
-    const { checkedinItem } = this.state;
-
-    return includes([
-      statuses.WITHDRAWN,
-      statuses.DECLARED_LOST,
-      statuses.MISSING,
-      statuses.LOST_AND_PAID,
-      statuses.AGED_TO_LOST,
-      statuses.RESTRICTED,
-    ], checkedinItem?.status?.name);
   }
 
   shouldClaimedReturnedModalBeShown = () => {
@@ -190,17 +178,25 @@ class ModalManager extends React.Component {
       checkedinItem,
       showConfirmModal,
     } = this.state;
+
     const {
       title,
       barcode,
       discoverySuppress,
       status: { name },
     } = checkedinItem;
+
     const materialType = upperFirst(checkedinItem?.materialType?.name ?? '');
     const discoverySuppressMessage = discoverySuppress
       ? formatMessage({ id:'ui-checkin.confirmModal.discoverySuppress' })
       : '';
     const status = formatMessage({ id: statusMessages[name] });
+    const heading = (
+      <FormattedMessage
+        id="ui-checkin.confirmModal.heading"
+        values={{ status: lowerFirst(status) }}
+      />
+    );
     const message = (
       <SafeHTMLMessage
         id="ui-checkin.confirmModal.message"
@@ -217,7 +213,7 @@ class ModalManager extends React.Component {
     return (
       <ConfirmationModal
         open={showConfirmModal}
-        heading={<FormattedMessage id="ui-checkin.confirmModal.heading" values={{ status }} />}
+        heading={heading}
         onConfirm={this.onConfirm}
         onCancel={this.onCancel}
         cancelLabel={<FormattedMessage id="ui-checkin.confirmModal.cancel" />}

--- a/src/consts.js
+++ b/src/consts.js
@@ -10,6 +10,10 @@ const statuses = {
   LOST_AND_PAID: 'Lost and paid',
   AGED_TO_LOST: 'Aged to lost',
   RESTRICTED: 'Restricted',
+  IN_PROCESS_NON_REQUESTABLE: 'In process (non-requestable)',
+  LONG_MISSING: 'Long missing',
+  UNAVAILABLE: 'Unavailable',
+  UNKNOWN: 'Unknown',
 };
 
 const statusMessages = {
@@ -19,6 +23,10 @@ const statusMessages = {
   'Lost and paid': 'ui-checkin.statuses.lostAndPaid',
   'Restricted': 'ui-checkin.statuses.restricted',
   'Aged to lost': 'ui-checkin.statuses.agedToLost',
+  'In process (non-requestable)': 'ui-checkin.statuses.inProcessNonRequestable',
+  'Long missing': 'ui-checkin.statuses.longMissing',
+  'Unavailable': 'ui-checkin.statuses.unavailable',
+  'Unknown': 'ui-checkin.statuses.unknown',
 };
 
 const requestTypes = {

--- a/src/util.js
+++ b/src/util.js
@@ -1,5 +1,10 @@
 import moment from 'moment-timezone';
-import { escape } from 'lodash';
+import {
+  escape,
+  includes,
+} from 'lodash';
+
+import { statuses } from './consts';
 
 export const escapeValue = (val) => {
   if (val.startsWith('<Barcode>') && val.endsWith('</Barcode>')) {
@@ -102,6 +107,21 @@ export function getCheckinSettings(checkinSettings) {
   } catch (e) {
     return {};
   }
+}
+
+export function shouldConfirmStatusModalBeShown(item) {
+  return includes([
+    statuses.WITHDRAWN,
+    statuses.DECLARED_LOST,
+    statuses.MISSING,
+    statuses.LOST_AND_PAID,
+    statuses.AGED_TO_LOST,
+    statuses.RESTRICTED,
+    statuses.IN_PROCESS_NON_REQUESTABLE,
+    statuses.LONG_MISSING,
+    statuses.UNAVAILABLE,
+    statuses.UNKNOWN,
+  ], item?.status?.name);
 }
 
 export default {};

--- a/test/bigtest/tests/check-in-test.js
+++ b/test/bigtest/tests/check-in-test.js
@@ -17,6 +17,10 @@ const statuses = [
   'Lost and paid',
   'Aged to lost',
   'Restricted',
+  'In process (non-requestable)',
+  'Long missing',
+  'Unavailable',
+  'Unknown',
 ];
 
 // Assumed to be several non-checked in item statuses

--- a/translations/ui-checkin/en.json
+++ b/translations/ui-checkin/en.json
@@ -94,6 +94,10 @@
   "statuses.lostAndPaid": "Lost and paid",
   "statuses.agedToLost": "Aged to lost",
   "statuses.restricted": "Restricted",
+  "statuses.inProcessNonRequestable": "In process (non-requestable)",
+  "statuses.longMissing": "Long missing",
+  "statuses.unavailable": "Unavailable",
+  "statuses.unknown": "Unknown",
 
   "permission.all": "Check in: All permissions"
 }


### PR DESCRIPTION
https://issues.folio.org/browse/UICHKIN-120

### Purpose
The user will have to confirm before `check in` an item with one of the statuses: `Long missing`, `In process (non-requestable)`, `Unavailable`, `Unknown`.

### Screenshot
![Screen Shot 2021-02-09 at 14 41 58](https://user-images.githubusercontent.com/49517355/107365229-2c67fe80-6ae5-11eb-83f3-608bf7f1d7ae.png)