### PR TITLE
UICHKIN-224 Optional prefix to indicate scan readiness in title

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 * Increment `@folio/stripes-cli` to `v2`. Refs UICHKIN-231.
 * Show confirmation modal when check in an item with one of the new statuses (Long missing, In process (non-requestable), Unavailable, Unknown). Refs UICHKIN-120.
 * Claim returned: Cancel SET COST fee at check in. Refs UICHKIN-225
+* Add support for optional `readyPrefix` property at the module level in stripes.config.js. If set, this prefix will be displayed in the title when the app is ready to receive a scanned item barcode. Implements UICHKIN-223.
 
 ## [4.0.0] (https://github.com/folio-org/ui-checkin/tree/v4.0.0) (2020-10-08)
 [Full Changelog](https://github.com/folio-org/ui-checkin/compare/v3.0.0...v4.0.0)

--- a/src/CheckIn.js
+++ b/src/CheckIn.js
@@ -33,7 +33,7 @@ import {
   FormattedTime,
 } from '@folio/stripes/components';
 import { effectiveCallNumber } from '@folio/stripes/util';
-import { IfPermission } from '@folio/stripes/core';
+import { IfPermission, TitleManager, withModules } from '@folio/stripes/core';
 
 import PrintButton from './components/PrintButton';
 import FeesFinesOwnedStatus from './components/FeesFinesOwnedStatus';
@@ -67,6 +67,9 @@ class CheckIn extends React.Component {
         records: PropTypes.arrayOf(PropTypes.object),
       }),
     }),
+    modules: PropTypes.shape({
+      app: PropTypes.arrayOf(PropTypes.object),
+    }),
     mutator: PropTypes.shape({
       query: PropTypes.shape({
         update: PropTypes.func,
@@ -85,6 +88,7 @@ class CheckIn extends React.Component {
     this.renderActions = this.renderActions.bind(this);
     this.handleOptionsChange = this.handleOptionsChange.bind(this);
     this.timer = undefined;
+    this.readyPrefix = props.modules?.app?.filter(el => el.module === '@folio/checkin')?.[0]?.readyPrefix;
 
     this.state = {
       showPickers: false
@@ -500,18 +504,22 @@ class CheckIn extends React.Component {
                 <Row>
                   <Col xs={9} sm={4}>
                     <Layout className="marginTopLabelSpacer">
-                      <Field
-                        autoFocus
-                        id="input-item-barcode"
-                        name="item.barcode"
-                        validationEnabled={false}
-                        placeholder={scanBarcodeMsg}
-                        ariaLabel={itemIdLabel}
-                        inputRef={barcodeRef}
-                        fullWidth
-                        component={TextField}
-                        data-test-check-in-barcode
-                      />
+                      <TitleManager prefix={(this.readyPrefix && this.state.readyToScan) ? this.readyPrefix : undefined}>
+                        <Field
+                          autoFocus
+                          id="input-item-barcode"
+                          name="item.barcode"
+                          validationEnabled={false}
+                          placeholder={scanBarcodeMsg}
+                          ariaLabel={itemIdLabel}
+                          inputRef={barcodeRef}
+                          onFocus={this.readyPrefix ? () => this.setState({ readyToScan: true }) : undefined}
+                          onBlur={this.readyPrefix ? () => this.setState({ readyToScan: false }) : undefined}
+                          fullWidth
+                          component={TextField}
+                          data-test-check-in-barcode
+                        />
+                      </TitleManager>
                       {hasSubmitErrors && <span className={styles.error}>{submitErrors.checkin}</span>}
                     </Layout>
                   </Col>
@@ -618,4 +626,4 @@ class CheckIn extends React.Component {
 
 export default stripesFinalForm({
   navigationCheck: true,
-})(injectIntl(CheckIn));
+})(injectIntl(withModules(CheckIn)));

--- a/src/CheckIn.js
+++ b/src/CheckIn.js
@@ -88,7 +88,7 @@ class CheckIn extends React.Component {
     this.renderActions = this.renderActions.bind(this);
     this.handleOptionsChange = this.handleOptionsChange.bind(this);
     this.timer = undefined;
-    this.readyPrefix = props.modules?.app?.filter(el => el.module === '@folio/checkin')?.[0]?.readyPrefix;
+    this.readyPrefix = props.modules?.app?.find(el => el.module === '@folio/checkin')?.readyPrefix;
 
     this.state = {
       showPickers: false


### PR DESCRIPTION
Adds support for an optional `readyPrefix` property at the module level in stripes.config.js. If set, this prefix will be displayed in the title when the app is ready to receive a scanned item barcode.