### PR TITLE
UICHKIN-244 also support circulation 10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 * Update the .gitignore file. Refs UICHKIN-232.
 * Add pull request template. Refs UICHKIN-233.
 * Add settings up for Jest/RTL tests. Refs UICHKIN-237.
+* Also support `inventory` `10.0`. Refs UICHKIN-244.
 
 ## [5.0.1] (https://github.com/folio-org/ui-checkin/tree/v5.0.1) (2021-04-13)
 [Full Changelog](https://github.com/folio-org/ui-checkin/compare/v5.0.0...v5.0.1)

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
       }
     ],
     "okapiInterfaces": {
-      "circulation": "9.0",
+      "circulation": "9.0 10.0",
       "configuration": "2.0",
       "item-storage": "8.0",
       "loan-policy-storage": "1.0 2.0",


### PR DESCRIPTION
The only breaking change in `circulation` `10.0` was the removal of the
`override-check-out-by-barcode` which is not used here, hence continuing
to support `9.0`.

Refs [UICHKIN-244](https://issues.folio.org/browse/UICHKIN-244)
