### PR TITLE
UICHKIN-245: Fix content cut off for two-page staff slips

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Add pull request template. Refs UICHKIN-233.
 * Add settings up for Jest/RTL tests. Refs UICHKIN-237.
 * Also support `inventory` `10.0`. Refs UICHKIN-244.
+* Fix content cut off for two-page staff slips. Refs UICHKIN-245.
 
 ## [5.0.1] (https://github.com/folio-org/ui-checkin/tree/v5.0.1) (2021-04-13)
 [Full Changelog](https://github.com/folio-org/ui-checkin/compare/v5.0.0...v5.0.1)

--- a/src/components/PrintButton/PrintButton.css
+++ b/src/components/PrintButton/PrintButton.css
@@ -1,3 +1,7 @@
 .hiddenContent {
   display: none;
 }
+
+.qlEditor {
+  overflow-y: unset !important;
+}

--- a/src/components/PrintButton/PrintButton.js
+++ b/src/components/PrintButton/PrintButton.js
@@ -46,7 +46,7 @@ class PrintButton extends React.Component {
           onAfterPrint={onAfterPrint}
         />
         <div className={css.hiddenContent}>
-          <div className="ql-editor" ref={this.printContentRef}>
+          <div className={`ql-editor ${css.qlEditor}`} ref={this.printContentRef}>
             <ComponentToPrint template={template} dataSource={dataSource} />
           </div>
         </div>


### PR DESCRIPTION
## Purpose
All of the content is printed so that it's readable.

## Approach
We don't need scroll for correct render our content before print.

## Refs
https://issues.folio.org/browse/UICHKIN-245

## Screenshots
Before
![image](https://user-images.githubusercontent.com/24813219/115037699-6b487500-9ed7-11eb-9cdf-0ab53b6cecb6.png)

After
![image](https://user-images.githubusercontent.com/24813219/115037600-4eac3d00-9ed7-11eb-9e4c-294daad3ce71.png)

<!-- OPTIONAL
#### TODOS and Open Questions
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.
-->

<!-- OPTIONAL
## Learning
  Help out not only your reviewer, but also your fellow developer!
  Sometimes there are key pieces of information that you used to come up
  with your solution. Don't let all that hard work go to waste! A
  pull request is a *perfect opportunity to share the learning that
  you did. Add links to blog posts, patterns, libraries or addons used
  to solve this problem.
-->

## Pre-Merge Checklist
Before merging this PR, please go through the following list and take appropriate actions.
- [x] I've added appropriate record to the CHANGELOG.md
- Does this PR meet or exceed the expected quality standards?
  - [x] Code coverage on new code is 80% or greater
  - [x] Duplications on new code is 3% or less
  - [x] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [x] If any API-related changes - okapi interfaces and permissions are reviewed/changed correspondingly
  - [x] There are no breaking changes in this PR.

If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
