### PR TITLE
UICHKIN-253 include fee/fine-related permissions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Add pull request template. Refs UICHKIN-233.
 * Add settings up for Jest/RTL tests. Refs UICHKIN-237.
 * Also support `inventory` `10.0`. Refs UICHKIN-244.
+* Include missing fee/fine-related permissions in `ui-checkin.all` pset. Refs UICHKIN-253.
 
 ## [5.0.3] (https://github.com/folio-org/ui-checkin/tree/v5.0.3) (2021-04-22)
 [Full Changelog](https://github.com/folio-org/ui-checkin/compare/v5.0.2...v5.0.3)

--- a/package.json
+++ b/package.json
@@ -51,7 +51,8 @@
           "module.checkin.enabled",
           "inventory.items.collection.get",
           "inventory-storage.service-points.collection.get",
-          "accounts.collection.get"
+          "accounts.collection.get",
+          "lost-item-fees-policies.collection.get"
         ]
       }
     ]

--- a/package.json
+++ b/package.json
@@ -50,7 +50,8 @@
           "usergroups.collection.get",
           "module.checkin.enabled",
           "inventory.items.collection.get",
-          "inventory-storage.service-points.collection.get"
+          "inventory-storage.service-points.collection.get",
+          "accounts.collection.get"
         ]
       }
     ]


### PR DESCRIPTION
The only available permission set, `ui-checkin.all`, was missing
fee/fine-related permissions, causing errors on check-in for items with
associated fees/fines:

* `accounts.collection.get`
* `lost-item-fees-policies.collection.get`

Refs [UICHKIN-253](https://issues.folio.org/browse/UICHKIN-253)
