### PR TITLE
UICHKIN-254: Update circulation interface dependency to support v11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * Add settings up for Jest/RTL tests. Refs UICHKIN-237.
 * Also support `inventory` `10.0`. Refs UICHKIN-244.
 * Include missing fee/fine-related permissions in `ui-checkin.all` pset. Refs UICHKIN-253.
+* Also support `circulation` `11.0`. Refs UICHKIN-254.
 
 ## [5.0.3] (https://github.com/folio-org/ui-checkin/tree/v5.0.3) (2021-04-22)
 [Full Changelog](https://github.com/folio-org/ui-checkin/compare/v5.0.2...v5.0.3)

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
       }
     ],
     "okapiInterfaces": {
-      "circulation": "9.0 10.0",
+      "circulation": "9.0 10.0 11.0",
       "configuration": "2.0",
       "item-storage": "8.0",
       "loan-policy-storage": "1.0 2.0",


### PR DESCRIPTION
## Purpose
There is a breaking change in mod-circulation (https://github.com/folio-org/mod-circulation/pull/854), circulation interface version will be updated to 11.0.  Other modules should update their dependencies to support this change.

**Do not merge. We have several associated pull request and we need merge them at the same time.**

**API changes**
circulation/override-renewal-by-barcode - will be removed
circulation/renew-by-barcode - request and response will be changed
Current changes will be effect ui-users module

## Refs
https://issues.folio.org/browse/UICHKIN-254