### PR TITLE
UICHKIN-234: Fix bug in backdating checkin time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * Also support `inventory` `10.0`. Refs UICHKIN-244.
 * Include missing fee/fine-related permissions in `ui-checkin.all` pset. Refs UICHKIN-253.
 * Also support `circulation` `11.0`. Refs UICHKIN-254.
+* Fix bug setting wrong checkin time when passing through DST. Fixes UICHKIN-234.
 
 ## [5.0.3] (https://github.com/folio-org/ui-checkin/tree/v5.0.3) (2021-04-22)
 [Full Changelog](https://github.com/folio-org/ui-checkin/compare/v5.0.2...v5.0.3)


### PR DESCRIPTION
https://issues.folio.org/browse/UICHKIN-234

Check-in allows the user to backdate the date/time recorded as the check-in time, but the prior implementation didn't take daylight savings time into account. I didn't find an especially elegant way to do so, but I think this works. I'm one of those people who enjoys the DST transitions for the bit of spice they add to life, but having to work with them in code is no fun at all.

<img width="1412" alt="Screen Shot 2021-05-27 at 9 00 09 AM" src="https://user-images.githubusercontent.com/1322242/119830147-f8fd8400-bec9-11eb-897c-0f2539f90353.png">
