### PR TITLE
UICHKIN-265: Fix failed build on ui-checkin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * Include missing fee/fine-related permissions in `ui-checkin.all` pset. Refs UICHKIN-253.
 * Also support `circulation` `11.0`. Refs UICHKIN-254.
 * Fix bug setting wrong checkin time when passing through DST. Fixes UICHKIN-234.
+* Fix failed build on ui-checkin. Fixes UICHKIN-265.
 
 ## [5.0.3] (https://github.com/folio-org/ui-checkin/tree/v5.0.3) (2021-04-22)
 [Full Changelog](https://github.com/folio-org/ui-checkin/compare/v5.0.2...v5.0.3)

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -1,15 +1,6 @@
-module.exports = (config) => {
-  const testIndex = './test/bigtest/index.js';
-  const preprocessors = {};
-  preprocessors[`${testIndex}`] = ['webpack'];
-
-  const configuration = {
-    files: [
-      { pattern: testIndex, watched: false },
-    ],
-
-    preprocessors
-  };
-
-  config.set(configuration);
-};
+/** @param {import('karma').Config} config */
+module.exports = config => config.set({
+  client: {
+    captureConsole: false,
+  },
+});


### PR DESCRIPTION
## Purpose
Fix failed build on ui-checkin

## Approach
Use karma.conf.js that consistency with other modules (https://github.com/folio-org/ui-users/blob/master/karma.conf.js)

## Stories
https://issues.folio.org/browse/UICHKIN-265

## Screenshot
### Before 
jenkins
![image](https://user-images.githubusercontent.com/24813219/121503645-edda4600-c9e9-11eb-9c41-9dbcc59325f4.png)
### After
jenkins
![image](https://user-images.githubusercontent.com/24813219/121503498-c84d3c80-c9e9-11eb-9648-1445a8368290.png)
local
![image](https://user-images.githubusercontent.com/24813219/121505382-73aac100-c9eb-11eb-8f5a-21afd1d359b6.png)

