### PR TITLE
Revert "Release v5.0.4"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,14 +1,12 @@
 # Change history for ui-checkin
 
-## [5.0.4] (https://github.com/folio-org/ui-checkin/tree/v5.0.4) (2021-06-11)
-[Full Changelog](https://github.com/folio-org/ui-checkin/compare/v5.0.3...v5.0.4)
+## 5.0.4 (IN PROGRESS)
 
 * Include missing fee/fine-related permissions in `ui-checkin.all` pset. Refs UICHKIN-253.
 * Fix failed build on ui-checkin. Fixes UICHKIN-265.
 
 ## [5.0.3] (https://github.com/folio-org/ui-checkin/tree/v5.0.3) (2021-04-22)
 [Full Changelog](https://github.com/folio-org/ui-checkin/compare/v5.0.2...v5.0.3)
-
 * Add patron comment token for staff slips. Refs UICHKIN-248.
 
 ## [5.0.2] (https://github.com/folio-org/ui-checkin/tree/v5.0.2) (2021-04-21)


### PR DESCRIPTION
Reverts folio-org/ui-checkin#443

You know what's cool about releasing a new version of something? Actually releasing a new version of it instead of just updating the CHANGELOG. 🤦 