### PR TITLE
UICHKIN-219: Fix incorrect check in time.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 * Also support `circulation` `11.0`. Refs UICHKIN-254.
 * Fix bug setting wrong checkin time when passing through DST. Fixes UICHKIN-234.
 * Fix failed build on ui-checkin. Fixes UICHKIN-265.
+* Fix incorrect check in time. Refs UICHKIN-219.
 
 ## [5.0.3] (https://github.com/folio-org/ui-checkin/tree/v5.0.3) (2021-04-22)
 [Full Changelog](https://github.com/folio-org/ui-checkin/compare/v5.0.2...v5.0.3)

--- a/src/CheckIn.js
+++ b/src/CheckIn.js
@@ -180,7 +180,7 @@ class CheckIn extends React.Component {
     const now = moment().tz(timeZone);
 
     change('item.checkinDate', now.format());
-    change('item.checkinTime', now.format('HH:mm'));
+    change('item.checkinTime', now.format().substring(11));
 
     this.setState({ showPickers: true });
   }

--- a/src/util.js
+++ b/src/util.js
@@ -86,13 +86,7 @@ export function convertToSlipData(source = {}, intl, timeZone, locale, slipName 
 
 export function buildDateTime(date, time, timeZone) {
   if (date && time) {
-    let timeString = time;
-
-    if (time.indexOf('T') > -1) {
-      timeString = time.split('T')[1];
-    }
-
-    const effectiveReturnDate = moment(`${date.substring(0, 10)}T${timeString}`).tz(timeZone);
+    const effectiveReturnDate = moment(`${date.substring(0, 10)}T${time}`);
 
     // Check for DST offset. 'time' is passed in adjusted to UTC from whatever time is specified in
     // the picker before being converted to a date/time in the local timezone. This works fine if


### PR DESCRIPTION
## Purpose
Fix incorrect check in time

## Approach
`change('item.checkinTime', now.format().substring(11));` - set to `Timepicker` time with time zone.
After changes above `Timepicker`  always return time with time zone.
Remove obsolete code 

## Stories
https://issues.folio.org/browse/UICHKIN-219

## Screenshot
### Before 
![image](https://user-images.githubusercontent.com/24813219/121859600-8f220e80-cd00-11eb-8d6f-4b47598e1736.png)
### After
![image](https://user-images.githubusercontent.com/24813219/121859481-6bf75f00-cd00-11eb-9258-3084304e371a.png)
