### PR TITLE
UICHKIN-256: Fix import paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change history for ui-checkin
 
+## [6.0.0] (IN PROGRESS)
+
+* Fix import paths. Refs UICHKIN-256.
+
 ## [5.1.0] (https://github.com/folio-org/ui-checkin/tree/v5.1.0) (2021-06-17)
 [Full Changelog](https://github.com/folio-org/ui-checkin/compare/v5.0.3...v5.1.0)
 * Update the .gitignore file. Refs UICHKIN-232.

--- a/src/components/ConfirmStatusModal/ConfirmStatusModal.js
+++ b/src/components/ConfirmStatusModal/ConfirmStatusModal.js
@@ -4,14 +4,12 @@ import PropTypes from 'prop-types';
 import { FormattedMessage } from 'react-intl';
 import {
   Modal,
+  ModalFooter,
   Button,
   Checkbox,
   Row,
-  Col
+  Col,
 } from '@folio/stripes/components';
-
-// eslint-disable-next-line import/no-extraneous-dependencies
-import mfCss from '@folio/stripes-components/lib/ModalFooter/ModalFooter.css';
 
 import PrintButton from '../PrintButton';
 
@@ -49,13 +47,12 @@ class ConfirmStatusModal extends React.Component {
     const { isPrintable } = this.state;
     const testId = uniqueId('confirm-status-');
     const footer = (
-      <div className={mfCss.modalFooterButtons}>
+      <ModalFooter>
         {isPrintable ?
           <PrintButton
             data-test-confirm-button
             buttonStyle="primary"
             id={`clickable-${testId}-confirm`}
-            buttonClass={mfCss.modalFooterButton}
             dataSource={slipData}
             template={slipTemplate}
             onBeforePrint={onConfirm}
@@ -69,11 +66,10 @@ class ConfirmStatusModal extends React.Component {
             id={`clickable-${testId}-confirm`}
             onClick={onConfirm}
             buttonStyle="primary"
-            buttonClass={mfCss.modalFooterButton}
           >
             <FormattedMessage id="ui-checkin.statusModal.close" />
           </Button>}
-      </div>
+      </ModalFooter>
     );
     const messageParts = message.map(m => <p>{m}</p>);
 

--- a/src/components/RouteForDeliveryModal/RouteForDeliveryModal.js
+++ b/src/components/RouteForDeliveryModal/RouteForDeliveryModal.js
@@ -3,14 +3,12 @@ import PropTypes from 'prop-types';
 import { FormattedMessage } from 'react-intl';
 import {
   Modal,
+  ModalFooter,
   Button,
   Checkbox,
   Row,
-  Col
+  Col,
 } from '@folio/stripes/components';
-
-// eslint-disable-next-line import/no-extraneous-dependencies
-import mfCss from '@folio/stripes-components/lib/ModalFooter/ModalFooter.css';
 
 import PrintButton from '../PrintButton';
 
@@ -45,11 +43,11 @@ class RouteForDeliveryModal extends React.Component {
     const { isPrintable } = this.state;
 
     return (
-      <div className={mfCss.modalFooterButtons}>
+      <ModalFooter>
         {isPrintable
           ? this.renderPrintButtonsGroup()
           : this.renderButtonsGroup()}
-      </div>
+      </ModalFooter>
     );
   }
 
@@ -65,7 +63,6 @@ class RouteForDeliveryModal extends React.Component {
       <>
         <PrintButton
           buttonStyle="primary"
-          buttonClass={mfCss.modalFooterButton}
           onBeforePrint={onCloseAndCheckout}
           dataSource={slipData}
           template={slipTemplate}
@@ -75,7 +72,6 @@ class RouteForDeliveryModal extends React.Component {
         </PrintButton>
         <PrintButton
           buttonStyle="primary"
-          buttonClass={mfCss.modalFooterButton}
           onBeforePrint={onClose}
           dataSource={slipData}
           template={slipTemplate}
@@ -97,7 +93,6 @@ class RouteForDeliveryModal extends React.Component {
       <>
         <Button
           buttonStyle="primary"
-          buttonClass={mfCss.modalFooterButton}
           onClick={onCloseAndCheckout}
           data-test="closeAndCheckout"
         >
@@ -105,7 +100,6 @@ class RouteForDeliveryModal extends React.Component {
         </Button>
         <Button
           buttonStyle="primary"
-          buttonClass={mfCss.modalFooterButton}
           onClick={onClose}
           data-test="close"
         >


### PR DESCRIPTION
## Purpose
Fix import paths

## Approach
Component imports should happen through the @folio/stripes/${repo} namespace rather than directly via the repo's private path. e.g. prefer
`import LocationSelection from '@folio/stripes/smart-components/LocationSelection';`
instead of
`import LocationSelection from '@folio/stripes-smart-components/lib/LocationSelection';`

In current case we cannot fix path because we import css file and we should use path to file(example in section screenshot).

But we can use `ModalFooter`  component instead of importing css file.
We can remove `mfCss.modalFooterButton` because current class was removed from css https://github.com/folio-org/stripes-components/blob/master/lib/ModalFooter/ModalFooter.css
We can change  from `<div className={mfCss.modalFooterButtons}>` to `<ModalFooter>` because  `ModalFooter` just add div with necessary class https://github.com/folio-org/stripes-components/blob/master/lib/ModalFooter/ModalFooter.js

## Stories
https://issues.folio.org/browse/UICHKIN-256

## Screenshot
![UICHKIN-256](https://user-images.githubusercontent.com/24813219/123837998-251a8380-d914-11eb-9972-6691b0590248.JPG)
