### PR TITLE
UICHKIN-273 provide `key` when rendering list

### DIFF
--- a/src/components/ConfirmStatusModal/ConfirmStatusModal.js
+++ b/src/components/ConfirmStatusModal/ConfirmStatusModal.js
@@ -71,7 +71,7 @@ class ConfirmStatusModal extends React.Component {
           </Button>}
       </ModalFooter>
     );
-    const messageParts = message.map(m => <p>{m}</p>);
+    const messageParts = message.map((m, i) => <p key={i}>{m}</p>);
 
     return (
       <Modal


### PR DESCRIPTION
When rendering a list in React, you have to provide a `key` attibute on
the list item. It's [the rule](https://reactjs.org/docs/lists-and-keys.html).

Refs [UICHKIN-273](https://issues.folio.org/browse/UICHKIN-273)
