### PR TITLE
UICHKIN-273 provide unique key in array iteration

### DIFF
--- a/src/components/ConfirmStatusModal/ConfirmStatusModal.js
+++ b/src/components/ConfirmStatusModal/ConfirmStatusModal.js
@@ -71,7 +71,7 @@ class ConfirmStatusModal extends React.Component {
           </Button>}
       </ModalFooter>
     );
-    const messageParts = message.map(m => <p>{m}</p>);
+    const messageParts = message.map((m, i) => <p key={i}>{m}</p>);
 
     return (
       <Modal

--- a/src/components/ConfirmStatusModal/ConfirmStatusModal.js
+++ b/src/components/ConfirmStatusModal/ConfirmStatusModal.js
@@ -71,7 +71,7 @@ class ConfirmStatusModal extends React.Component {
           </Button>}
       </ModalFooter>
     );
-    const messageParts = message.map((m, i) => <p key={i}>{m}</p>);
+    const messageParts = message.map(m => <p key={m}>{m}</p>);
 
     return (
       <Modal


### PR DESCRIPTION
Refs UICHKIN-273

## Purpose

When rendering a list in React, you have to provide a `key` attibute on
the list item. It's [the rule](https://reactjs.org/docs/lists-and-keys.html).

## Approach

Provide the message-parts as `key`; we don't have anything else. 

## Refs

[UICHKIN-273](https://issues.folio.org/browse/UICHKIN-273); see also #456, an inferior version of this PR which wrongly used the iteration index as a key. 

