### PR TITLE
UICHKIN-299: fix extra blank page at printing

### DIFF
--- a/src/checkin.css
+++ b/src/checkin.css
@@ -12,3 +12,9 @@
 .error {
   color: var(--error);
 }
+
+@media print {
+  body {
+    height: auto !important;
+  }
+}


### PR DESCRIPTION
## Purpose
Fix extra blank page at printing

## Approach
Adding global auto height on printing.

## Refs
https://issues.folio.org/browse/UICHKIN-299
https://issues.folio.org/browse/UICIRC-683

## Screenshots
![Checkin-empty-page](https://user-images.githubusercontent.com/88130496/130569438-82ed7005-0c7c-4c7a-915f-777213a7984b.png)
![checkin fixed](https://user-images.githubusercontent.com/88130496/130569818-276d3869-14bc-4dcc-bd5e-b38bb99050d5.jpg)
![Circ-emty-page-edit-](https://user-images.githubusercontent.com/88130496/130569934-ed54e3cd-cc07-4043-98be-fc17feac5dbe.png)
![circulation fixed](https://user-images.githubusercontent.com/88130496/130570242-94fb40a7-9d04-40ae-b6ca-9f94fac906e4.jpg)