### PR TITLE
UICHKIN-308 upgrade react-intl-safe-html

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change history for ui-checkin
 
+## IN PROGRESS
+
+* Upgrade `@folio/react-intl-safe-html` for compatibility with `@folio/stripes` `v7`. Refs UICHKIN-308.
+
 ## [6.0.0] (https://github.com/folio-org/ui-checkin/tree/v6.0.0) (2021-09-30)
 [Full Changelog](https://github.com/folio-org/ui-checkin/compare/v5.1.0...v6.0.0)
 

--- a/package.json
+++ b/package.json
@@ -108,7 +108,7 @@
     "webpack": "^4.16.0"
   },
   "dependencies": {
-    "@folio/react-intl-safe-html": "^2.0.0",
+    "@folio/react-intl-safe-html": "^3.1.0",
     "dateformat": "^2.0.0",
     "final-form": "^4.19.1",
     "html-to-react": "^1.3.3",


### PR DESCRIPTION
Upgrade `@folio/react-intl-safe-html` for compatibility with
`@folio/stripes` `v7` (react 17, react-intl 5).

Refs [UICHKIN-308](https://issues.folio.org/browse/UICHKIN-308), [STRIPES-769](https://issues.folio.org/browse/STRIPES-769)
