### PR TITLE
UICHKIN-312: fix fee/fine details button

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## IN PROGRESS
 
 * Upgrade `@folio/react-intl-safe-html` for compatibility with `@folio/stripes` `v7`. Refs UICHKIN-308.
+* Fix the issue when fee/fine details doesn't open up if fee/fines have been refunded. Refs UICHKIN-312.
 
 ## [6.0.0] (https://github.com/folio-org/ui-checkin/tree/v6.0.0) (2021-09-30)
 [Full Changelog](https://github.com/folio-org/ui-checkin/compare/v5.1.0...v6.0.0)

--- a/test/bigtest/interactors/check-in.js
+++ b/test/bigtest/interactors/check-in.js
@@ -45,6 +45,7 @@ import ConfrmModalInteractor from './confirm-modal';
   barcodeInputIsFocused = isPresent('[data-test-check-in-barcode]:focus');
   confirmStatusModalPresent = isPresent('[data-test-confirm-status-modal]');
   confirmFeeFineOwnedStatusPresent = isPresent('[data-test-fee-fine-owned-status]');
+  confirmFeeFineDetailsPresent = isPresent('[data-test-fee-fine-details] a');
   barcode = fillable('#input-item-barcode');
   blurBarcodeField = blurrable('#input-item-barcode');
   clickEnter = clickable('#clickable-add-item');

--- a/test/bigtest/network/scenarios/account.js
+++ b/test/bigtest/network/scenarios/account.js
@@ -2,6 +2,9 @@ export default server => {
   server.get('/accounts', {
     accounts: [{
       id: 'accounts id',
+      status: {
+        name: 'Open',
+      },
     }],
     totalRecords: 1,
   });

--- a/test/bigtest/network/scenarios/accounts.js
+++ b/test/bigtest/network/scenarios/accounts.js
@@ -3,9 +3,15 @@ export default server => {
     accounts: [
       {
         id: 'accounts id #1',
+        status: {
+          name: 'Open',
+        },
       },
       {
         id: 'accounts id #2',
+        status: {
+          name: 'Open',
+        },
       },
     ],
     totalRecords: 2,

--- a/test/bigtest/tests/fee-fine-test.js
+++ b/test/bigtest/tests/fee-fine-test.js
@@ -20,8 +20,8 @@ describe('CheckIn fee(s) fine(s)', () => {
         'account',
         'inventory-items',
         'circulation-check-in-by-barcode-without-user',
-        'circulation-requests'
-      ]
+        'circulation-requests',
+      ],
     });
 
     const checkIn = new CheckInInteractor();
@@ -39,17 +39,10 @@ describe('CheckIn fee(s) fine(s)', () => {
       beforeEach(async function () {
         await checkIn.selectEllipse();
         await wait();
-        await checkIn.selectFeeFineDetails();
       });
 
-      it('should not navigate to fee/fine details page', function () {
-        const {
-          search,
-          pathname,
-        } = this.location;
-
-        expect(pathname + search)
-          .to.include('/checkin');
+      it('should not be rendered', function () {
+        expect(checkIn.confirmFeeFineDetailsPresent).to.be.false;
       });
     });
 
@@ -66,8 +59,8 @@ describe('CheckIn fee(s) fine(s)', () => {
         'account',
         'inventory-items',
         'circulation-check-in-by-barcode',
-        'circulation-requests'
-      ]
+        'circulation-requests',
+      ],
     });
 
     const checkIn = new CheckInInteractor();
@@ -113,8 +106,8 @@ describe('CheckIn fee(s) fine(s)', () => {
         'accounts',
         'inventory-items',
         'circulation-check-in-by-barcode',
-        'circulation-requests'
-      ]
+        'circulation-requests',
+      ],
     });
 
     const checkIn = new CheckInInteractor();

--- a/test/jest/__mock__/stripesComponents.mock.js
+++ b/test/jest/__mock__/stripesComponents.mock.js
@@ -1,8 +1,12 @@
 import React from 'react';
 
 jest.mock('@folio/stripes/components', () => ({
-  Button: jest.fn(({ children }) => (
-    <button data-test-button type="button">
+  Button: jest.fn(({ children, onClick }) => (
+    <button
+      data-test-button
+      type="button"
+      onClick={onClick}
+    >
       <span>
         {children}
       </span>


### PR DESCRIPTION
## Purpose
 Fix the issue when fee/fine details doesn't open up if fee/fines have been refunded

## Approach
Now we looking not only for fee/fines with status "Open", but for "Closed" too.
If we have several fee/fines with "Open" status - the button will redirect into view pane, with open fee/fines. If we have only one open fee/fine - the button will redirect directly on it.
This behaviout don't depend on number of "Closed" fee/fines.
The next case - when we have no open fee/fines, but have with status closed.
Redirect policy works here like with open fee/fines. If their number greate than one - the button will redirect you into view pane with closed fee/fines. And if we have only one - redirect directly on it.
And finaly if we have no fee/fines at all, the button will not be rendered.
This behavior was discussed in the comments to the ticket.

## Refs
https://issues.folio.org/browse/UICHKIN-312