### PR TITLE
UICHKIN-317: use constants instead of hardcoded value for query limits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## IN PROGRESS
 
 * Upgrade `@folio/react-intl-safe-html` for compatibility with `@folio/stripes` `v7`. Refs UICHKIN-308.
+* Use `MAX_RECORDS` constant instead of hardcoded value for query limits. Refs UICHKIN-317.
 
 ## [6.0.1] (https://github.com/folio-org/ui-checkin/tree/v6.0.1) (2021-11-08)
 [Full Changelog](https://github.com/folio-org/ui-checkin/compare/v6.0.0...v6.0.1)

--- a/src/Scan.js
+++ b/src/Scan.js
@@ -12,7 +12,7 @@ import {
   isEmpty,
   keyBy,
   upperFirst,
-  cloneDeep
+  cloneDeep,
 } from 'lodash';
 
 import {
@@ -22,7 +22,11 @@ import {
 } from '@folio/stripes/components';
 
 import CheckIn from './CheckIn';
-import { statuses, cancelFeeClaimReturned } from './consts';
+import {
+  statuses,
+  cancelFeeClaimReturned,
+  MAX_RECORDS,
+} from './consts';
 import ConfirmStatusModal from './components/ConfirmStatusModal';
 import RouteForDeliveryModal from './components/RouteForDeliveryModal';
 import ModalManager from './ModalManager';
@@ -146,13 +150,13 @@ class Scan extends React.Component {
     staffSlips: {
       type: 'okapi',
       records: 'staffSlips',
-      path: 'staff-slips-storage/staff-slips?limit=100',
+      path: `staff-slips-storage/staff-slips?limit=${MAX_RECORDS}`,
       throwErrors: false,
     },
     servicePoints: {
       type: 'okapi',
       records: 'servicepoints',
-      path: 'service-points?limit=100',
+      path: `service-points?limit=${MAX_RECORDS}`,
     },
     checkIn: {
       type: 'okapi',
@@ -206,7 +210,7 @@ class Scan extends React.Component {
     item: {
       checkinDate: '',
       checkinTime: '',
-    }
+    },
   };
 
   setFocusInput = () => {
@@ -631,9 +635,9 @@ class Scan extends React.Component {
           title: item.title,
           barcode: item.barcode,
           materialType: upperFirst(get(item, 'materialType.name', '')),
-          pickupServicePoint: get(request, 'pickupServicePoint.name', '')
+          pickupServicePoint: get(request, 'pickupServicePoint.name', ''),
         }}
-      />
+      />,
     ];
 
     if (patronComments) {
@@ -708,7 +712,7 @@ class Scan extends React.Component {
       state: {
         itemBarcode: deliveryItem.item.barcode,
         patronBarcode: nextRequest.requester.barcode,
-      }
+      },
     });
   }
 
@@ -732,9 +736,9 @@ class Scan extends React.Component {
           title: item.title,
           barcode: item.barcode,
           materialType: upperFirst(get(item, 'materialType.name', '')),
-          servicePoint: destinationServicePoint
+          servicePoint: destinationServicePoint,
         }}
-      />
+      />,
     ];
 
     return (

--- a/src/consts.js
+++ b/src/consts.js
@@ -54,4 +54,4 @@ export const cancelFeeClaimReturned = {
   TYPE_ACTION: 'Cancelled item returned',
 };
 
-export default {};
+export const MAX_RECORDS = '1000';


### PR DESCRIPTION
## Purpose
We should use constants instead of hardcoded value for query limits.

## Approach
Limits was upgraded to `1000`, it was tested on kiwi env - everything is fine.
I also removed default export of empty object from constants. I believe it was added to trick one of the linter rules, which prefere default export instead of named. But now we don't need it any more because we have more than one export from constants file.

## Refs
https://issues.folio.org/browse/UICHKIN-317