### PR TITLE
UICHKIN-163: unhandled errors bubble up on UI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * Add RTL/Jest testing for `CheckInFooter` component. Refs UICHKIN-278.
 * Update mocha in package.json. Refs UICHKIN-324.
 * Also support `circulation` `12.0`. Refs UICHKIN-310.
+* Unhandled errors bubble up on UI to say that somethin go wrong. Refs UICHKIN-163.
 
 ## [6.0.1] (https://github.com/folio-org/ui-checkin/tree/v6.0.1) (2021-11-08)
 [Full Changelog](https://github.com/folio-org/ui-checkin/compare/v6.0.0...v6.0.1)

--- a/src/Scan.js
+++ b/src/Scan.js
@@ -486,7 +486,12 @@ class Scan extends React.Component {
   }
 
   handleTextError(error) {
-    throw error;
+    this.setState({
+      itemError: {
+        message: error,
+        _error: 'unknownError',
+      },
+    });
   }
 
   handleJsonError({
@@ -497,15 +502,15 @@ class Scan extends React.Component {
       } = {},
     ] = [],
   }) {
-    const itemError = (!parameters || !parameters.length)
+    const itemError = (parameters?.length)
       ? {
-        barcode: <FormattedMessage id="ui-checkin.unknownError" />,
-        _error: 'unknownError',
-      }
-      : {
         message,
         barcode: parameters[0].value,
         _error: parameters[0].key,
+      }
+      : {
+        message,
+        _error: 'unknownError',
       };
 
     this.setState({ itemError });
@@ -756,6 +761,7 @@ class Scan extends React.Component {
   }
 
   renderErrorModal({ message, barcode }) {
+    const { formatMessage } = this.props.intl;
     let errorMessage;
     let label;
 
@@ -768,7 +774,11 @@ class Scan extends React.Component {
       );
       label = <FormattedMessage id="ui-checkin.itemNotFound" />;
     } else {
-      errorMessage = message;
+      errorMessage = (
+        <div>
+          {`${formatMessage({ id: 'ui-checkin.errorModal.unhandledError' })} ${message || null}`}
+        </div>
+      );
       label = <FormattedMessage id="ui-checkin.itemNotCheckedIn" />;
     }
 

--- a/test/bigtest/tests/check-in-test.js
+++ b/test/bigtest/tests/check-in-test.js
@@ -69,9 +69,9 @@ describe('CheckIn', () => {
             message: `No item with barcode ${params.itemBarcode} exists`,
             parameters: [{
               key: 'itemBarcode',
-              value: params.itemBarcode
-            }]
-          }]
+              value: params.itemBarcode,
+            }],
+          }],
         });
       });
 
@@ -118,8 +118,8 @@ describe('CheckIn', () => {
               parameters: [{
                 key : 'itemBarcode',
                 value : params.itemBarcode,
-              }]
-            }]
+              }],
+            }],
           });
         });
 
@@ -131,7 +131,7 @@ describe('CheckIn', () => {
       });
 
       it('should show error message', () => {
-        expect(checkIn.barcodeError).to.equal(errorMessage);
+        expect(checkIn.barcodeError).to.equal(`This is an unhandled exception. ${errorMessage}`);
       });
     });
   });
@@ -143,8 +143,8 @@ describe('CheckIn', () => {
         title: 'Best Book Ever',
         userId: 'test',
         materialType: {
-          name: 'book'
-        }
+          name: 'book',
+        },
       });
 
       await checkIn.barcode('9676761472500').clickEnter();
@@ -235,8 +235,8 @@ describe('CheckIn', () => {
         barcode: 9676761472500,
         title: 'Best Book Ever',
         materialType: {
-          name: 'book'
-        }
+          name: 'book',
+        },
       });
 
       await checkIn.clickChangeDate();
@@ -255,8 +255,8 @@ describe('CheckIn', () => {
         barcode: 9676761472500,
         title: 'Best Book Ever',
         materialType: {
-          name: 'book'
-        }
+          name: 'book',
+        },
       });
 
       await checkIn.barcode('9676761472500').clickEnter();
@@ -276,8 +276,8 @@ describe('CheckIn', () => {
         barcode: 9676761472500,
         title: 'Best Book Ever',
         materialType: {
-          name: 'book'
-        }
+          name: 'book',
+        },
       });
 
       await checkIn.barcode('9676761472500').clickEnter();
@@ -297,10 +297,10 @@ describe('CheckIn', () => {
         barcode: 9676761472500,
         title: 'Best Book Ever',
         materialType: {
-          name: 'book'
+          name: 'book',
         },
         instanceId: 'lychee',
-        holdingsRecordId: 'apple'
+        holdingsRecordId: 'apple',
       });
 
       await checkIn.barcode('9676761472500').clickEnter();
@@ -327,8 +327,8 @@ describe('CheckIn', () => {
         barcode: '9676761472500',
         title: 'Best Book Ever',
         materialType: {
-          name: 'book'
-        }
+          name: 'book',
+        },
       });
 
       await checkIn.clickChangeTime();
@@ -349,13 +349,13 @@ describe('CheckIn', () => {
         barcode: 9676761472500,
         title: 'Best Book Ever',
         materialType: {
-          name: 'book'
+          name: 'book',
         },
         status: {
           name: 'In transit',
         },
         instanceId: 'lychee',
-        holdingsRecordId: 'apple'
+        holdingsRecordId: 'apple',
       });
 
       await checkIn.barcode('9676761472500').clickEnter();
@@ -372,7 +372,7 @@ describe('CheckIn', () => {
         barcode: 9676761472500,
         status: {
           name: 'In transit',
-        }
+        },
       });
       this.server.create('servicePoint', { id: 1 });
 
@@ -391,7 +391,7 @@ describe('CheckIn', () => {
         barcode: 9676761472500,
         status: {
           name: 'In transit',
-        }
+        },
       });
       this.server.create('servicePoint', { id: 2 });
 
@@ -410,16 +410,16 @@ describe('CheckIn', () => {
         barcode: 9676761472500,
         title: 'Best Book Ever',
         materialType: {
-          name: 'book'
+          name: 'book',
         },
         status: {
           name: 'Awaiting pickup',
         },
         location: {
-          name: 'Main Library'
+          name: 'Main Library',
         },
         instanceId: 'lychee',
-        holdingsRecordId: 'apple'
+        holdingsRecordId: 'apple',
       });
 
       this.server.create('request', { status: 'Open - Awaiting pickup', id: item.id });
@@ -449,13 +449,13 @@ describe('CheckIn', () => {
         barcode: 9676761472500,
         title: 'Best Book Ever',
         materialType: {
-          name: 'book'
+          name: 'book',
         },
         status: {
           name: 'In transit',
         },
         instanceId: 'lychee',
-        holdingsRecordId: 'apple'
+        holdingsRecordId: 'apple',
       });
 
       await checkIn.barcode('9676761472500').clickEnter();
@@ -475,7 +475,7 @@ describe('CheckIn', () => {
       item = this.server.create('item', 'withLoan', {
         title: 'Best Book Ever',
         materialType: {
-          name: 'book'
+          name: 'book',
         },
         circulationNotes: [
           {
@@ -488,7 +488,7 @@ describe('CheckIn', () => {
                 firstName: faker.name.firstName(),
               },
             },
-            date: faker.date.past()
+            date: faker.date.past(),
           },
           {
             note: 'test note 1',
@@ -500,14 +500,14 @@ describe('CheckIn', () => {
                 firstName: faker.name.firstName(),
               },
             },
-            date: faker.date.future()
-          }
+            date: faker.date.future(),
+          },
         ],
         status: {
           name: 'In transit',
         },
         instanceId: 'lychee',
-        holdingsRecordId: 'apple'
+        holdingsRecordId: 'apple',
       });
 
       await checkIn.barcode(item.barcode).clickEnter();
@@ -542,11 +542,11 @@ describe('CheckIn', () => {
         barcode: 9676761472501,
         title: 'Best Book Ever',
         materialType: {
-          name: 'book'
+          name: 'book',
         },
         numberOfPieces: 2,
         instanceId: 'lychee',
-        holdingsRecordId: 'apple'
+        holdingsRecordId: 'apple',
       });
 
       await checkIn.barcode('9676761472501').clickEnter();
@@ -567,11 +567,11 @@ describe('CheckIn', () => {
         barcode: 9676761472501,
         title: 'Best Book Ever',
         materialType: {
-          name: 'book'
+          name: 'book',
         },
         numberOfPieces: 2,
         instanceId: 'lychee',
-        holdingsRecordId: 'apple'
+        holdingsRecordId: 'apple',
       });
 
       await checkIn.barcode(firstItem.barcode).clickEnter();
@@ -599,14 +599,14 @@ describe('CheckIn', () => {
             note: 'test note',
             noteType: 'Check in',
             staffOnly: false,
-          }
+          },
         ],
         materialType: {
-          name: 'book'
+          name: 'book',
         },
         numberOfPieces: 1,
         instanceId: 'lychee',
-        holdingsRecordId: 'apple'
+        holdingsRecordId: 'apple',
       });
 
       await checkIn.barcode('9676761472501').clickEnter();
@@ -627,14 +627,14 @@ describe('CheckIn', () => {
             note: 'test note',
             noteType: 'Check in',
             staffOnly: false,
-          }
+          },
         ],
         materialType: {
-          name: 'book'
+          name: 'book',
         },
         numberOfPieces: 1,
         instanceId: 'lychee',
-        holdingsRecordId: 'apple'
+        holdingsRecordId: 'apple',
       });
 
       await checkIn.barcode('9676761472501').clickEnter();
@@ -656,17 +656,17 @@ describe('CheckIn', () => {
             note: 'test note',
             noteType: 'Check in',
             staffOnly: false,
-          }
+          },
         ],
         materialType: {
-          name: 'book'
+          name: 'book',
         },
         status: {
-          name: 'Missing'
+          name: 'Missing',
         },
         numberOfPieces: 2,
         instanceId: 'lychee',
-        holdingsRecordId: 'apple'
+        holdingsRecordId: 'apple',
       });
 
       await checkIn.barcode('9676761472501').clickEnter();

--- a/translations/ui-checkin/en.json
+++ b/translations/ui-checkin/en.json
@@ -14,6 +14,7 @@
   "timeReturnedLabel": "Time returned",
   "endSession": "End session",
   "errorModal.noItemFound": "The barcode <strong>{barcode}</strong> could not be found.",
+  "errorModal.unhandledError": "This is an unhandled exception.",
   "noItems": "No items have been entered yet.",
   "timeReturned": "Time returned",
   "title": "Title",


### PR DESCRIPTION
## Puprose
Unhandled errors should bubble up on UI to say that somethin go wrong.

## Approach
As you can see on screenshot below, I simulate error with 500 `statusCode` and content type `text`.
In code we have only one error which we directly handle, when `item` with passed `barcode` is not founded. All other errors will show modal with `this is an unhandled exception` text.

All tests will pass after https://github.com/folio-org/ui-checkin/pull/484 will be merged.

## Refs
https://issues.folio.org/browse/UICHKIN-163

## Screenshots
![image](https://user-images.githubusercontent.com/88130496/147666457-2aef583b-ebe9-4c6d-ae56-27751bce7719.png)