### PR TITLE
UICHKIN-320: Fix date formats when slip print

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 * Unhandled errors bubble up on UI to say that somethin go wrong. Refs UICHKIN-163.
 * Also support `circulation` `13.0`. Refs UICHKIN-319.
 * Perform Wildcard Item Lookup Before Performing Check in Transactions in Check in App. Refs UICHKIN-309.
+* Fix date formats when slip print. Refs UICHKIN-320.
 
 ## [6.0.1] (https://github.com/folio-org/ui-checkin/tree/v6.0.1) (2021-11-08)
 [Full Changelog](https://github.com/folio-org/ui-checkin/compare/v6.0.0...v6.0.1)

--- a/src/util.js
+++ b/src/util.js
@@ -29,6 +29,15 @@ export function convertToSlipData(source = {}, intl, timeZone, locale, slipName 
     request = {},
     requester = {},
   } = source;
+  const DEFAULT_DATE_OPTIONS = {
+    timeZone,
+    locale,
+    year: 'numeric',
+    month: 'short',
+    day: 'numeric',
+    hour: 'numeric',
+    minute: 'numeric',
+  };
 
   const slipData = {
     'staffSlip.Name': slipName,
@@ -62,7 +71,9 @@ export function convertToSlipData(source = {}, intl, timeZone, locale, slipName 
     'item.loanType': item.loanType,
     'item.numberOfPieces': item.numberOfPieces,
     'item.descriptionOfPieces': item.descriptionOfPieces,
-    'item.lastCheckedInDateTime': item.lastCheckedInDateTime,
+    'item.lastCheckedInDateTime': item.lastCheckedInDateTime
+      ? intl.formatDate(item.lastCheckedInDateTime, DEFAULT_DATE_OPTIONS)
+      : item.lastCheckedInDateTime,
     'item.fromServicePoint': item.fromServicePoint,
     'item.toServicePoint': item.toServicePoint,
     'item.effectiveLocationInstitution': item.effectiveLocationInstitution,
@@ -72,10 +83,10 @@ export function convertToSlipData(source = {}, intl, timeZone, locale, slipName 
     'request.servicePointPickup': request.servicePointPickup,
     'request.deliveryAddressType': request.deliveryAddressType,
     'request.requestExpirationDate': request.requestExpirationDate
-      ? intl.formatDate(request.requestExpirationDate, { timeZone, locale })
+      ? intl.formatDate(request.requestExpirationDate, DEFAULT_DATE_OPTIONS)
       : request.requestExpirationDate,
     'request.holdShelfExpirationDate': request.holdShelfExpirationDate
-      ? intl.formatDate(request.holdShelfExpirationDate, { timeZone, locale })
+      ? intl.formatDate(request.holdShelfExpirationDate, DEFAULT_DATE_OPTIONS)
       : request.holdShelfExpirationDate,
     'request.requestID': request.requestID,
     'request.patronComments': request.patronComments,

--- a/src/util.test.js
+++ b/src/util.test.js
@@ -10,11 +10,11 @@ import {
   convertToSlipData,
   escapeValue,
   getCheckinSettings,
-  shouldConfirmStatusModalBeShown
+  shouldConfirmStatusModalBeShown,
 } from './util';
 
 import {
-  statuses
+  statuses,
 } from './consts';
 
 describe('escapeValue', () => {
@@ -104,7 +104,7 @@ describe('convertToSlipData', () => {
       'holdShelfExpirationDate': 'holdShelfExpirationDate',
       'requestID': 'requestID',
       'patronComments': 'patronComments',
-    }
+    },
   };
 
   it('substitutes values', () => {
@@ -140,7 +140,7 @@ describe('convertToSlipData', () => {
     expect(o['item.loanType']).toEqual(source.item.loanType);
     expect(o['item.numberOfPieces']).toEqual(source.item.numberOfPieces);
     expect(o['item.descriptionOfPieces']).toEqual(source.item.descriptionOfPieces);
-    expect(o['item.lastCheckedInDateTime']).toEqual(source.item.lastCheckedInDateTime);
+    expect(o['item.lastCheckedInDateTime']).toEqual(`lastCheckedInDateTime ${tz} ${locale}`);
     expect(o['item.fromServicePoint']).toEqual(source.item.fromServicePoint);
     expect(o['item.toServicePoint']).toEqual(source.item.toServicePoint);
     expect(o['item.effectiveLocationInstitution']).toEqual(source.item.effectiveLocationInstitution);
@@ -180,8 +180,8 @@ describe('convertToSlipData', () => {
       ...source,
       requester: {
         ...source.requester,
-        barcode: noop()
-      }
+        barcode: noop(),
+      },
     };
     const o = convertToSlipData(sourceWithoutRequesterBarcode, intl, tz, locale, 'Chicken');
 


### PR DESCRIPTION
## Purpose
Dates in check-in module doesn't match expected format when printing staff slip (expected result from circulation staff slip templates).

## Refs
https://issues.folio.org/browse/UICHKIN-320

## Screenshot
before:
![image](https://user-images.githubusercontent.com/88130496/154912239-9a949c4b-8ede-4ecb-841c-ccc93e8bb989.png)

after:
![image](https://user-images.githubusercontent.com/88130496/154912064-0c73cd5b-5438-4769-ab1b-f809da75bbf7.png)
