### PR TITLE
UICHKIN-243: Compile Translation Files into AST Format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## IN PROGRESS
 * Add id for Pane component. Refs UICHKIN-329.
+* Compile Translation Files into AST Format. Refs UICHKIN-243.
 
 ## [7.0.0] (https://github.com/folio-org/ui-checkin/tree/v7.0.0) (2022-02-24)
 [Full Changelog](https://github.com/folio-org/ui-checkin/compare/v6.0.1...v7.0.0)

--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "test:jest": "jest --ci --coverage --colors",
     "lint": "eslint .",
     "build-mod-descriptor": "stripes mod descriptor --full --strict | jq '.[]' > module-descriptor.json ",
-    "formatjs-compile": "formatjs compile-folder --ast --format simple ./translations/ui-checkin ./translations/checkin/compiled"
+    "formatjs-compile": "formatjs compile-folder --ast --format simple ./translations/ui-checkin ./translations/ui-checkin/compiled"
   },
   "devDependencies": {
     "@babel/plugin-proposal-class-properties": "^7.13.0",


### PR DESCRIPTION
## Purpose
Compile Translation Files into AST Format.

## Approach
- Destination folder was renamed for consistency with other modules (Just for example https://github.com/folio-org/ui-users/blob/master/package.json#L843)
- We run locally command "yarn formatjs-compile" and we don't get any errors.

## Refs
https://issues.folio.org/browse/UICHKIN-329

#### TODOS and Open Questions
Hello @zburke 
Could you please confirm that Jenkinsfile are deprecated and we don't need add 
`runScripts = [
   ['formatjs-compile': ''],
  ]`
to Jenkinsfile.?