### PR TITLE
UICHKIN-334: fix heading of `Request delivery slip`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 * Add id for Pane component. Refs UICHKIN-329.
 * Compile Translation Files into AST Format. Refs UICHKIN-243.
 * Refactor away from react-intl-safe-html Refs UICHKIN-260.
+* Fix heading of `Request delivery slip`. Refs UICHKIN-334.
 
 ## [7.0.0] (https://github.com/folio-org/ui-checkin/tree/v7.0.0) (2022-02-24)
 [Full Changelog](https://github.com/folio-org/ui-checkin/compare/v6.0.1...v7.0.0)

--- a/src/Scan.js
+++ b/src/Scan.js
@@ -37,6 +37,8 @@ import {
   getCheckinSettings,
 } from './util';
 
+const REQUEST_DELIVERY_HEADING = 'Request delivery';
+
 class Scan extends React.Component {
   static propTypes = {
     intl: PropTypes.object,
@@ -727,7 +729,7 @@ class Scan extends React.Component {
       },
     } = this.props;
 
-    const slipData = convertToSlipData(staffSlipContext, intl, timezone, locale, 'Request delivery');
+    const slipData = convertToSlipData(staffSlipContext, intl, timezone, locale, REQUEST_DELIVERY_HEADING);
     const message = (
       <FormattedMessage
         id="ui-checkin.statusModal.delivery.message"

--- a/src/Scan.js
+++ b/src/Scan.js
@@ -727,7 +727,7 @@ class Scan extends React.Component {
       },
     } = this.props;
 
-    const slipData = convertToSlipData(staffSlipContext, intl, timezone, locale);
+    const slipData = convertToSlipData(staffSlipContext, intl, timezone, locale, 'Request delivery');
     const message = (
       <FormattedMessage
         id="ui-checkin.statusModal.delivery.message"


### PR DESCRIPTION
## Purpose
Heading of `request delivery` slips should be consistent.

## Approach
`convertToSlipData` accept `slipName` which is `Hold` by default. We just need to pass correct value for delivery modal.
Also I should note that these values are not localized.
Localization will be discussed with PO as a separate task/story.

## Refs
https://issues.folio.org/browse/UICHKIN-334

## Screenshot
before:
![image](https://user-images.githubusercontent.com/88130496/161525006-a751707e-4b78-4401-8093-e62fa981e18a.png)

after:
![image](https://user-images.githubusercontent.com/88130496/161525064-0e4ac9f6-82dc-4025-99e0-5bacc1d44507.png)
