### PR TITLE
UICHKIN-280: Add Jest/RTL tests for `ClaimedReturnedModal` component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 * Add id for Pane component. Refs UICHKIN-329.
 * Compile Translation Files into AST Format. Refs UICHKIN-243.
 * Refactor away from react-intl-safe-html Refs UICHKIN-260.
+* Add Jest/RTL testing for `ClaimedReturnedModal` component in `src\components\ClaimedReturnedModal`. Refs UICHKIN-280.
 
 ## [7.0.1] (https://github.com/folio-org/ui-checkin/tree/v7.0.1) (2022-04-06)
 [Full Changelog](https://github.com/folio-org/ui-checkin/compare/v7.0.0...v7.0.1)

--- a/src/components/ClaimedReturnedModal/ClaimedReturnedModal.js
+++ b/src/components/ClaimedReturnedModal/ClaimedReturnedModal.js
@@ -59,7 +59,13 @@ const ClaimedReturnedModal = ({ item, open, onCancel, onConfirm }) => {
 };
 
 ClaimedReturnedModal.propTypes = {
-  item: PropTypes.object,
+  item: PropTypes.shape({
+    title: PropTypes.string,
+    barcode: PropTypes.string,
+    materialType:  PropTypes.shape({
+      name: PropTypes.string,
+    }),
+  }).isRequired,
   onCancel: PropTypes.func.isRequired,
   onConfirm: PropTypes.func.isRequired,
   open: PropTypes.bool.isRequired,

--- a/src/components/ClaimedReturnedModal/ClaimedReturnedModal.js
+++ b/src/components/ClaimedReturnedModal/ClaimedReturnedModal.js
@@ -14,6 +14,7 @@ const ClaimedReturnedModal = ({ item, open, onCancel, onConfirm }) => {
     <div>
       <Button
         data-test-cancel-button
+        data-testid="cancelButton"
         buttonStyle="primary"
         onClick={onCancel}
       >
@@ -21,12 +22,14 @@ const ClaimedReturnedModal = ({ item, open, onCancel, onConfirm }) => {
       </Button>
       <Button
         data-test-found-button
+        data-testid="foundButton"
         onClick={() => onConfirm(claimedReturnedResolutions.FOUND)}
       >
         <FormattedMessage id="ui-checkin.claimedReturnedModal.resolution.found" />
       </Button>
       <Button
         data-test-returned-button
+        data-testid="returnedButton"
         onClick={() => onConfirm(claimedReturnedResolutions.RETURNED)}
       >
         <FormattedMessage id="ui-checkin.claimedReturnedModal.resolution.returned" />

--- a/src/components/ClaimedReturnedModal/ClaimedReturnedModal.test.js
+++ b/src/components/ClaimedReturnedModal/ClaimedReturnedModal.test.js
@@ -1,0 +1,142 @@
+import React from 'react';
+import {
+  render,
+  screen,
+  fireEvent,
+  within,
+} from '@testing-library/react';
+
+import '../../../test/jest/__mock__';
+
+import { FormattedMessage } from 'react-intl';
+
+import {
+  Modal,
+  Button,
+} from '@folio/stripes/components';
+
+import ClaimedReturnedModal from './ClaimedReturnedModal';
+
+import { getById } from '../../../test/jest/helpers/utils';
+
+import { claimedReturnedResolutions } from '../../consts';
+
+FormattedMessage.mockImplementation(({ id, values }) => {
+  const renderValues = (currentValues) => (
+    <>
+      { currentValues.title }
+      { currentValues.barcode }
+      { currentValues.materialType }
+    </>
+  );
+
+  return (
+    <span>
+      {id}
+      {
+        values && renderValues(values)
+      }
+    </span>
+  );
+});
+
+describe('ClaimedReturnedModal', () => {
+  const labelIds = {
+    cancel: 'ui-checkin.multipieceModal.cancel',
+    found: 'ui-checkin.claimedReturnedModal.resolution.found',
+    returned: 'ui-checkin.claimedReturnedModal.resolution.returned',
+    label: 'ui-checkin.claimedReturnedModal.label',
+    message: 'ui-checkin.claimedReturnedModal.message',
+  };
+  const testIds = {
+    cancelButton: 'cancelButton',
+    foundButton: 'foundButton',
+    returnedButton: 'returnedButton',
+    modalWindow: 'modal-window',
+  };
+  const item = {
+    title: 'testTitle',
+    barcode: 'testBarcode',
+    materialType: {
+      name: 'testMaterialTypeName',
+    },
+  };
+  const onCancel = jest.fn();
+  const onConfirm = jest.fn();
+  const open = true;
+  const defaultProps = {
+    item,
+    onCancel,
+    onConfirm,
+    open,
+  };
+
+  beforeEach(() => {
+    render(
+      <ClaimedReturnedModal
+        {...defaultProps}
+      />
+    );
+  });
+
+  afterEach(() => {
+    Modal.mockClear();
+    onCancel.mockClear();
+    onConfirm.mockClear();
+  });
+
+  it('should render "Modal" label', () => {
+    expect(getById(testIds.modalWindow).getByText(labelIds.label)).toBeInTheDocument();
+  });
+
+  it('should execute "Modal" with correct props', () => {
+    expect(Modal).toHaveBeenCalledWith(expect.objectContaining({
+      dismissible: true,
+      open,
+      onCancel,
+    }), {});
+  });
+
+  it('should render "cancel" button', () => {
+    expect(getById(testIds.cancelButton).getByText(labelIds.cancel)).toBeInTheDocument();
+  });
+
+  it('should execute correct function on "cancel" button click', () => {
+    expect(onCancel).not.toBeCalled();
+
+    fireEvent.click(screen.getByTestId(testIds.cancelButton));
+
+    expect(onCancel).toBeCalled();
+  });
+
+  it('should render "found" button', () => {
+    expect(getById(testIds.foundButton).getByText(labelIds.found)).toBeInTheDocument();
+  });
+
+  it('should execute correct function on "found" button click', () => {
+    expect(onConfirm).not.toBeCalled();
+
+    fireEvent.click(screen.getByTestId(testIds.foundButton));
+
+    expect(onConfirm).toHaveBeenCalledWith(claimedReturnedResolutions.FOUND);
+  });
+
+  it('should render "returned" button', () => {
+    expect(getById(testIds.returnedButton).getByText(labelIds.returned)).toBeInTheDocument();
+  });
+
+  it('should execute correct function on "returned" button click', () => {
+    expect(onConfirm).not.toBeCalled();
+
+    fireEvent.click(screen.getByTestId(testIds.returnedButton));
+
+    expect(onConfirm).toHaveBeenCalledWith(claimedReturnedResolutions.RETURNED);
+  });
+
+  it('should correctly render "message"', () => {
+    expect(screen.getByText(new RegExp(labelIds.message))).toBeInTheDocument();
+    expect(screen.getByText(new RegExp(item.title))).toBeInTheDocument();
+    expect(screen.getByText(new RegExp(item.barcode))).toBeInTheDocument();
+    expect(screen.getByText(new RegExp(item.materialType.name))).toBeInTheDocument();
+  });
+});

--- a/src/components/ClaimedReturnedModal/ClaimedReturnedModal.test.js
+++ b/src/components/ClaimedReturnedModal/ClaimedReturnedModal.test.js
@@ -3,7 +3,6 @@ import {
   render,
   screen,
   fireEvent,
-  within,
 } from '@testing-library/react';
 
 import '../../../test/jest/__mock__';
@@ -12,12 +11,11 @@ import { FormattedMessage } from 'react-intl';
 
 import {
   Modal,
-  Button,
 } from '@folio/stripes/components';
 
 import ClaimedReturnedModal from './ClaimedReturnedModal';
 
-import { getById } from '../../../test/jest/helpers/utils';
+import { getById } from '../../../test/jest/helpers';
 
 import { claimedReturnedResolutions } from '../../consts';
 

--- a/src/components/ClaimedReturnedModal/ClaimedReturnedModal.test.js
+++ b/src/components/ClaimedReturnedModal/ClaimedReturnedModal.test.js
@@ -7,8 +7,6 @@ import {
 
 import '../../../test/jest/__mock__';
 
-import { FormattedMessage } from 'react-intl';
-
 import {
   Modal,
 } from '@folio/stripes/components';
@@ -18,25 +16,6 @@ import ClaimedReturnedModal from './ClaimedReturnedModal';
 import { getById } from '../../../test/jest/helpers';
 
 import { claimedReturnedResolutions } from '../../consts';
-
-FormattedMessage.mockImplementation(({ id, values }) => {
-  const renderValues = (currentValues) => (
-    <>
-      { currentValues.title }
-      { currentValues.barcode }
-      { currentValues.materialType }
-    </>
-  );
-
-  return (
-    <span>
-      {id}
-      {
-        values && renderValues(values)
-      }
-    </span>
-  );
-});
 
 describe('ClaimedReturnedModal', () => {
   const labelIds = {
@@ -132,9 +111,6 @@ describe('ClaimedReturnedModal', () => {
   });
 
   it('should correctly render "message"', () => {
-    expect(screen.getByText(new RegExp(labelIds.message))).toBeInTheDocument();
-    expect(screen.getByText(new RegExp(item.title))).toBeInTheDocument();
-    expect(screen.getByText(new RegExp(item.barcode))).toBeInTheDocument();
-    expect(screen.getByText(new RegExp(item.materialType.name))).toBeInTheDocument();
+    expect(screen.getByText(labelIds.message)).toBeInTheDocument();
   });
 });

--- a/test/jest/__mock__/stripesComponents.mock.js
+++ b/test/jest/__mock__/stripesComponents.mock.js
@@ -1,9 +1,14 @@
 import React from 'react';
 
 jest.mock('@folio/stripes/components', () => ({
-  Button: jest.fn(({ children, onClick }) => (
+  Button: jest.fn(({
+    children,
+    onClick,
+    'data-testid': testId,
+  }) => (
     <button
       data-test-button
+      data-testid={testId}
       type="button"
       onClick={onClick}
     >

--- a/test/jest/helpers/index.js
+++ b/test/jest/helpers/index.js
@@ -1,0 +1,2 @@
+export * from './utils';
+export { dafault as translationsProperties } from './translationsProperties';

--- a/test/jest/helpers/utils.js
+++ b/test/jest/helpers/utils.js
@@ -1,0 +1,7 @@
+/* eslint-disable import/prefer-default-export */
+import {
+  screen,
+  within,
+} from '@testing-library/react';
+
+export const getById = (id) => within(screen.getByTestId(id));

--- a/test/jest/helpers/utils.js
+++ b/test/jest/helpers/utils.js
@@ -1,7 +1,21 @@
-/* eslint-disable import/prefer-default-export */
 import {
   screen,
   within,
 } from '@testing-library/react';
 
 export const getById = (id) => within(screen.getByTestId(id));
+
+export const componentPropsCheck = (Component, testId, expectedProps, partialCompare = false) => {
+  const propertiesForCompare = Component.mock.calls
+    .reverse()
+    .find(item => item[0]['data-testid'] === testId);
+
+  const resultExpectedProps = partialCompare
+    ? expect.objectContaining(expectedProps)
+    : {
+      ...expectedProps,
+      'data-testid': testId,
+    };
+
+  expect(propertiesForCompare[0]).toStrictEqual(resultExpectedProps);
+};


### PR DESCRIPTION
## Purpose
Add Jest/RTL testing for `ClaimedReturnedModal` component in `src\components\ClaimedReturnedModal`.

## Refs
https://issues.folio.org/browse/UICHKIN-280

## Screenshots
![image](https://user-images.githubusercontent.com/88130496/162435247-13fe497f-9f92-4c90-959d-608a6adbbe0c.png)