### PR TITLE
UICHKIN-344: Switching service points is not recognized by the check-in app

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## IN PROGRESS
 
 * Add Jest/RTL testing for `ComponentToPrint` component. Refs UICHKIN-281.
+* Switching service points is not recognized by the check-in app. Refs UICHKIN-344.
 
 ## [7.1.0] (https://github.com/folio-org/ui-checkin/tree/v7.1.0) (2022-06-29)
 [Full Changelog](https://github.com/folio-org/ui-checkin/compare/v7.0.1...v7.1.0)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## IN PROGRESS
 
 * Add Jest/RTL testing for `ComponentToPrint` component. Refs UICHKIN-281.
-* Switching service points is not recognized by the check-in app. Refs UICHKIN-344.
+* Retrieve service point from `okapi.currentUser` because `stripes.user` is out of sync. Refs UICHKIN-344.
 
 ## [7.1.0] (https://github.com/folio-org/ui-checkin/tree/v7.1.0) (2022-06-29)
 [Full Changelog](https://github.com/folio-org/ui-checkin/compare/v7.0.1...v7.1.0)

--- a/src/Scan.js
+++ b/src/Scan.js
@@ -339,12 +339,12 @@ class Scan extends React.Component {
     } = data;
     const {
       mutator: { checkIn },
-      stripes: { user },
       intl: { timeZone },
+      okapi,
     } = this.props;
     const { itemClaimedReturnedResolution } = this.state;
 
-    const servicePointId = get(user, 'user.curServicePoint.id', '');
+    const servicePointId = get(okapi, 'currentUser.curServicePoint.id', '');
 
     const checkInDate = buildDateTime(checkinDate, checkinTime, timeZone, moment().tz(timeZone));
     const requestData = {


### PR DESCRIPTION
## Purpose
Initially when we go to Checkin service, change service point and then try to check in some item we sent incorrect `servicePointId` param to the server.

## Refs
[UICHKIN-344](https://issues.folio.org/browse/UICHKIN-344)