### PR TITLE
UICHKIN-357: Support inventory 12.0 in okapiInterfaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Add Jest/RTL testing for `ComponentToPrint` component. Refs UICHKIN-281.
 * Add improvement and Jest/RTL testing for `CheckIn` component. Refs UICHKIN-343.
+* Also support `inventory` `12.0`. Refs UICHKIN-357.
 
 ## [7.1.1] (https://github.com/folio-org/ui-checkin/tree/v7.1.1) (2022-07-27)
 [Full Changelog](https://github.com/folio-org/ui-checkin/compare/v7.1.0...v7.1.1)

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "okapiInterfaces": {
       "circulation": "9.0 10.0 11.0 12.0 13.0",
       "configuration": "2.0",
-      "inventory": "10.0 11.0",
+      "inventory": "10.0 11.0 12.0",
       "loan-policy-storage": "1.0 2.0",
       "users": "15.0"
     },


### PR DESCRIPTION
Add version 12.0 to the list of supported inventory interface versions.

DELETE /inventory/instances and DELETE /inventory/items have been deleting all records.

MODINV-731 changed them to delete records by CQL, this requires a major interface version bump.

ui-checkin doesn't need any code change because it doesn't use these two DELETE APIs.