### PR TITLE
UICHKIN-369: bump stripes to 8.0.0 for Orchid/2023-R1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Change history for ui-checkin
 
+## IN PROGRESS
+* Bump major versions of several @folio/stripes-* packages. Refs UICHKIN-369.
+
 ## [7.2.0] (https://github.com/folio-org/ui-checkin/tree/v7.2.0) (2022-10-20)
 [Full Changelog](https://github.com/folio-org/ui-checkin/compare/v7.1.1...v7.2.0)
 

--- a/package.json
+++ b/package.json
@@ -81,10 +81,10 @@
     "@bigtest/mocha": "^0.5.0",
     "@bigtest/react": "^0.1.2",
     "@folio/eslint-config-stripes": "^6.0.0",
-    "@folio/stripes": "^7.0.0",
+    "@folio/stripes": "^8.0.0",
     "@folio/stripes-cli": "^2.0.0",
-    "@folio/stripes-components": "^10.0.0",
-    "@folio/stripes-core": "^8.0.0",
+    "@folio/stripes-components": "^11.0.0",
+    "@folio/stripes-core": "^9.0.0",
     "@formatjs/cli": "^4.2.20",
     "@testing-library/jest-dom": "^5.11.9",
     "@testing-library/react": "^11.2.5",
@@ -124,7 +124,7 @@
     "react-to-print": "^2.3.2"
   },
   "peerDependencies": {
-    "@folio/stripes": "^7.0.0",
+    "@folio/stripes": "^8.0.0",
     "react": "^17.0.2",
     "react-intl": "^5.7.0",
     "react-router-dom": "^5.2.0"


### PR DESCRIPTION
## Purpose
Bump major versions of several @folio/stripes-* packages.

## Refs
[UICHKIN-369](https://issues.folio.org/browse/UICHKIN-369)