### PR TITLE
UICHKIN-375: Use camel case notation for all data-testid

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## IN PROGRESS
 
+* Use camel case notation for all data-testid. Refs UICHKIN-375.
+
 ## [8.0.0] (https://github.com/folio-org/ui-checkin/tree/v8.0.0) (2023-02-22)
 [Full Changelog](https://github.com/folio-org/ui-checkin/compare/v7.2.0...v8.0.0)
 

--- a/src/components/CheckinNoteModal/CheckInNoteModal.test.js
+++ b/src/components/CheckinNoteModal/CheckInNoteModal.test.js
@@ -158,7 +158,7 @@ describe('CheckinNoteModal', () => {
       id: undefined,
     });
 
-    expect(container.getByTestId('modal-window')
+    expect(container.getByTestId('modalWindow')
       .getAttribute('id'))
       .toContain('confirmation-');
   });

--- a/src/components/ClaimedReturnedModal/ClaimedReturnedModal.test.js
+++ b/src/components/ClaimedReturnedModal/ClaimedReturnedModal.test.js
@@ -29,7 +29,7 @@ describe('ClaimedReturnedModal', () => {
     cancelButton: 'cancelButton',
     foundButton: 'foundButton',
     returnedButton: 'returnedButton',
-    modalWindow: 'modal-window',
+    modalWindow: 'modalWindow',
   };
   const item = {
     title: 'testTitle',

--- a/src/components/ConfirmStatusModal/ConfirmStatusModal.test.js
+++ b/src/components/ConfirmStatusModal/ConfirmStatusModal.test.js
@@ -17,7 +17,7 @@ import ConfirmStatusModal from './ConfirmStatusModal';
 import PrintButton from '../PrintButton';
 
 jest.mock('../PrintButton', () => jest.fn(({ children, ...rest }) => (
-  <button type="button" data-testid="print-button" {...rest}>
+  <button type="button" data-testid="printButton" {...rest}>
     {children}
   </button>
 )));
@@ -133,7 +133,7 @@ describe('ConfirmStatusModal', () => {
     });
 
     it('After clicking on checkbox "PrintButton" should disappear', () => {
-      const printButton = screen.getByTestId('print-button');
+      const printButton = screen.getByTestId('printButton');
 
       fireEvent.click(screen.getByText(messageIds.printSlip));
 

--- a/test/jest/__mock__/stripesComponents.mock.js
+++ b/test/jest/__mock__/stripesComponents.mock.js
@@ -63,7 +63,7 @@ jest.mock('@folio/stripes/components', () => ({
   Modal: jest.fn(({ children, label, footer, id, ...rest }) => (
     <div
       id={id}
-      data-testid="modal-window"
+      data-testid="modalWindow"
       {...rest}
     >
       <p>{label}</p>


### PR DESCRIPTION
## Purpose
- Use camel case notation for all data-testid
- Remove magic strings for testIds and labelIds

## Refs
https://issues.folio.org/browse/UICHKIN-375