### PR TITLE
UICHKIN-375: Use camel case notation for all data-testid

### DIFF
--- a/src/components/ConfirmStatusModal/ConfirmStatusModal.test.js
+++ b/src/components/ConfirmStatusModal/ConfirmStatusModal.test.js
@@ -16,8 +16,12 @@ import {
 import ConfirmStatusModal from './ConfirmStatusModal';
 import PrintButton from '../PrintButton';
 
+const testIds = {
+  printButton: 'printButton',
+};
+
 jest.mock('../PrintButton', () => jest.fn(({ children, ...rest }) => (
-  <button type="button" data-testid="printButton" {...rest}>
+  <button type="button" data-testid={testIds.printButton} {...rest}>
     {children}
   </button>
 )));
@@ -133,7 +137,7 @@ describe('ConfirmStatusModal', () => {
     });
 
     it('After clicking on checkbox "PrintButton" should disappear', () => {
-      const printButton = screen.getByTestId('printButton');
+      const printButton = screen.getByTestId(testIds.printButton);
 
       fireEvent.click(screen.getByText(messageIds.printSlip));
 


### PR DESCRIPTION
## Purpose
- Use camel case notation for all data-testid
- Remove magic strings for testIds and labelIds

## Refs
https://issues.folio.org/browse/UICHKIN-375

## Notes
Fix feedback in  https://github.com/folio-org/ui-checkin/pull/572