### PR TITLE
UICHKIN-389: Upgrade babel config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 * Also support `circulation` `14.0`. Refs UICHKIN-381.
 * Added requestDate token. Refs UICHKIN-384.
 * Add sessionId field to check-in request body JSON. Refs UICHKIN-385.
+* Upgrade babel config. Refs UICHKIN-389.
 
 ## [8.0.1] (https://github.com/folio-org/ui-checkin/tree/v8.0.1) (2023-03-28)
 [Full Changelog](https://github.com/folio-org/ui-checkin/compare/v8.0.0...v8.0.1)

--- a/package.json
+++ b/package.json
@@ -75,9 +75,6 @@
   "devDependencies": {
     "@babel/core": "^7.17.12",
     "@babel/eslint-parser": "^7.17.0",
-    "@babel/plugin-proposal-class-properties": "^7.13.0",
-    "@babel/plugin-proposal-decorators": "^7.13.5",
-    "@babel/plugin-transform-runtime": "^7.13.10",
     "@bigtest/interactor": "^0.7.0",
     "@bigtest/mocha": "^0.5.0",
     "@bigtest/react": "^0.1.2",

--- a/test/jest/babel.config.js
+++ b/test/jest/babel.config.js
@@ -1,12 +1,5 @@
+const { babelOptions } = require('@folio/stripes-cli');
+
 module.exports = {
-  presets: [
-    '@babel/preset-env',
-    ['@babel/preset-react', { 'runtime': 'automatic' }],
-  ],
-  plugins: [
-    ['@babel/plugin-proposal-decorators', { legacy: true }],
-    ['@babel/plugin-proposal-class-properties', { loose: true }],
-    ['@babel/plugin-proposal-private-methods', { loose: true }],
-    '@babel/plugin-transform-runtime',
-  ],
+  ...babelOptions,
 };


### PR DESCRIPTION
## Purpose
Upgrade babel config

## Approach
Pulling the babel config directly from stripes-webpack via stripes-cli, in order to guarantee the babel plugins, versions, and config are all aligned.

## Refs
https://issues.folio.org/browse/UICHKIN-389