### PR TITLE
UICHKIN-392: Circulation time out error - permission problem

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Change history for ui-checkin
 
+## 9.1.0 IN PROGRESS
+* Fix circulation timeout issue. Refs UICHKIN-392.
+
 ## [9.0.0] (https://github.com/folio-org/ui-checkin/tree/v9.0.0) (2023-10-12)
 [Full Changelog](https://github.com/folio-org/ui-checkin/compare/v8.0.1...v9.0.0)
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@folio/checkin",
-  "version": "9.0.0",
+  "version": "9.1.0",
   "description": "Item Check-in",
   "repository": "folio-org/ui-checkin",
   "publishConfig": {


### PR DESCRIPTION
## Purpose
When a user goes to **checkin** page and check in an item and then log out, we can see unnecessary "end-patron-action-session" request.
This request will fail because there is no required token.
Furthermore, that request should not be sent if a user is logged out.
Also, I found not removed event listeners that could lead to memory leaks.

See the same implementation for checkout module [here](https://github.com/folio-org/ui-checkout/pull/826)

## Approach
The best solution that I found is using global object "window" to store timer entity. In this case timer will be available through all app, even on the login page that is necessary for us.

Also, I tried an approach with local resources (manifest) but on the login page data was lost.

## Refs
[UICHKIN-392](https://issues.folio.org/browse/UICHKIN-392)

## Notes
"src/CheckIn.js" file does not have tests at all.
We have separate ticket to cover this big file by jest/RTL tests - [UICHKIN-287](https://issues.folio.org/browse/UICHKIN-287).
In the scope of that ticket new functionality from this PR will be covered as well.
