### PR TITLE
UICHKIN-401: Also support feesfines interface version 19.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 9.1.0 IN PROGRESS
 * Fix circulation timeout issue. Refs UICHKIN-392.
+* Also support `feesfines` interface version `19.0`. Refs UICHKIN-401.
 
 ## [9.0.0] (https://github.com/folio-org/ui-checkin/tree/v9.0.0) (2023-10-12)
 [Full Changelog](https://github.com/folio-org/ui-checkin/compare/v8.0.1...v9.0.0)

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
       "inventory": "10.0 11.0 12.0 13.0",
       "loan-policy-storage": "1.0 2.0",
       "users": "15.0 16.0",
-      "feesfines": "17.0 18.0"
+      "feesfines": "17.0 18.0 19.0"
     },
     "permissionSets": [
       {


### PR DESCRIPTION
## Purpose
Also support `feesfines` interface version `19.0`

## Approach
Changes was in endpoint `/accounts` the field `status` has become required, this does not affect the current module.
This is part of `Quesnelia (R1 2024)` release
Should be merged after merging https://issues.folio.org/browse/MODFEE-337

## Refs
https://issues.folio.org/browse/UICHKIN-401