### PR TITLE
UICHKIN-420 - Time offset issue when crossing DST boundary. 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * UI tests replacement with RTL/Jest for view CheckIn. Refs UICHKIN-287.
 * UI tests replacement with RTL/Jest for Scan component. Refs UICHKIN-289.
 * Add support for displaySummary token for Staff Slips. Refs UICHKIN-415.
+* Remove DST boundary adjustment for item return time. Refs UICHKIN-420.
 
 ## [9.0.1] (https://github.com/folio-org/ui-checkin/tree/v9.0.1) (2023-10-23)
 [Full Changelog](https://github.com/folio-org/ui-checkin/compare/v9.0.0...v9.0.1)

--- a/src/util.js
+++ b/src/util.js
@@ -122,21 +122,6 @@ export function buildDateTime(date, time, timezone, now) {
     const formattedTime = moment(time, ['HH:mm', 'HH:mm a']).format('HH:mm');
     const effectiveReturnDate = moment.tz(`${formattedDate}T${formattedTime}`, timezone);
 
-    // Check for DST offset. 'time' is passed in adjusted to UTC from whatever time is specified in
-    // the picker before being converted to a date/time in the local timezone. This works fine if
-    // there is no difference between the UTC offset *now* and the offset at a date/time specified
-    // to count items as returned. If there is, due to a change from daylight savings time to standard
-    // time between the two dates, the recorded time will be an hour off. Unless we do somethng
-    // like this:
-    const inDstNow = now.isDST();
-    const inDstThen = effectiveReturnDate.isDST();
-
-    if (inDstNow && !inDstThen) {
-      effectiveReturnDate.add(1, 'hours');
-    } else if (!inDstNow && inDstThen) {
-      effectiveReturnDate.subtract(1, 'hours');
-    }
-
     return effectiveReturnDate.toISOString();
   } else {
     return moment(now).toISOString();

--- a/src/util.test.js
+++ b/src/util.test.js
@@ -238,24 +238,31 @@ describe('buildDateTime', () => {
     expect(v).toMatch('2021-02-14T17:14:00.000Z');
   });
 
-  it('given an effective return date before DST, returns an ISO-8601 string', () => {
+  it('given an effective return date in non-DST, currenty in DST, returns an ISO-8601 string', () => {
     const d = '2021-03-13';
     const t = '12:14:00';
     const z = 'America/New_York';
+
     const now = moment('2021-03-14T12:14:00').tz(z);
     const v = buildDateTime(d, t, z, now);
 
-    expect(v).toMatch('2021-03-13T18:14:00.000Z');
+    // America/New_York is offset -4 hrs in DST, -5 hours in non-DST.
+    // expect to match the non-DST offset of 5 hours in UTC time...
+    const expected = moment.tz(`${d}T${t}`, 'UTC').add(5, 'hours').toISOString();
+    expect(v).toMatch(expected);
   });
 
-  it('given an effective return date after DST, returns an ISO-8601 string', () => {
+  it('given an effective return date in DST, currently non-DST, returns an ISO-8601 string', () => {
     const d = '2021-11-06';
     const t = '12:14:00';
     const z = 'America/New_York';
     const now = moment('2021-11-07T12:14:00').tz(z);
     const v = buildDateTime(d, t, z, now);
 
-    expect(v).toMatch('2021-11-06T15:14:00.000Z');
+    // America/New_York is offset -4 hrs in DST, -5 hours in non-DST.
+    // expect to match the DST offset of 4 hours in UTC time...
+    const expected = moment.tz(`${d}T${t}`, 'UTC').add(4, 'hours').toISOString();
+    expect(v).toMatch(expected);
   });
 });
 


### PR DESCRIPTION
If the time zone is currently in DST, and the return needs to be backdated to a time in non-DST, the logic applies a 1hour offset prior to submitting the time. When the time is presented in the checked-in items list, the time displayed has a 1 hour difference from the time that was entered by the user.

## Approach

Remove DST compensation code that was added back in [UICHKIN-234](https://folio-org.atlassian.net/browse/UICHKIN-234) Timepicker applies no offset to its output time string. It's supplied with `UTC` here, regardless of the tenant-set timeZone. Appropriate time localization happens courtesy of the date to determine a datetime string is DST or not given its time zone/locale information. `FormattedDate` is smart enough to know this, so it needs no pre-adjustment of the time value when it localizes its provided UTC ISO stamp.
