### PR TITLE
UICHKIN-421: Add support for Barcode tag with sanitize

### DIFF
--- a/src/components/ComponentToPrint/ComponentToPrint.js
+++ b/src/components/ComponentToPrint/ComponentToPrint.js
@@ -41,7 +41,7 @@ class ComponentToPrint extends React.Component {
     const {
       dataSource,
     } = this.props;
-    const componentStr = sanitize(this.template(dataSource));
+    const componentStr = sanitize(this.template(dataSource), { ADD_TAGS: ['Barcode'] });
     const Component = this.parser.parseWithInstructions(componentStr, () => true, this.rules) || null;
 
     return (


### PR DESCRIPTION
## Purpose
Only certain HTML tags should be rendered when displaying staff slips. Add support for `Barcode `tag with sanitize.

# Refs
https://issues.folio.org/browse/UICHKIN-421

## Approach
For resolve current problem we should use `DOMPurify.sanitize` confirmed with John. Add support for Barcode tag with sanitize. Change log was already updated.
