### PR TITLE
UICHKIN-424: Check in - Do not trim barcode before it is sent to backend for processing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 9.2.0 IN PROGRESS
 * Remove bigtests from github actions. Refs UICHKIN-425.
 * Update upload-artifact actions from v1 and v2 to v4. Refs UICHKIN-431.
+* Remove barcode trimming before it is sent to backend for processing. Refs UICHKIN-424.
 
 ## [9.1.1] (https://github.com/folio-org/ui-checkin/tree/v9.1.1) (2024-03-27)
 [Full Changelog](https://github.com/folio-org/ui-checkin/compare/v9.1.0...v9.1.1)

--- a/src/Scan.js
+++ b/src/Scan.js
@@ -381,7 +381,7 @@ class Scan extends React.Component {
       sessionId: this.props.resources.checkInSession.sessionId,
       servicePointId,
       checkInDate,
-      itemBarcode: barcode.trim(),
+      itemBarcode: barcode,
     };
 
     // For items that have the status 'Claimed returned', the claimedReturnedResolution


### PR DESCRIPTION
## Purpose
Remove barcode trimming before it is sent to backend for processing.

## Refs
[UICHKIN-424](https://folio-org.atlassian.net/browse/UICHKIN-424)