### PR TITLE
UICHKIN-439: Implement feature toggle for switch between circulation/check-in-by-barcode and circulation-bff/loans/check-in-by-barcode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change history for ui-checkin
 
+## 10.1.0 IN PROGRESS
+
+* Implement feature toggle for switch between `circulation/check-in-by-barcode` and `circulation-bff/loans/check-in-by-barcode`. Refs UICHKIN-439.
+
 ## [10.0.0] (https://github.com/folio-org/ui-checkin/tree/v10.0.0) (2025-01-16)
 [Full Changelog](https://github.com/folio-org/ui-checkin/compare/v9.2.1...v10.0.0)
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@folio/checkin",
-  "version": "10.0.0",
+  "version": "10.1.0",
   "description": "Item Check-in",
   "repository": "folio-org/ui-checkin",
   "publishConfig": {
@@ -28,7 +28,9 @@
       "inventory": "10.0 11.0 12.0 13.0 14.0",
       "loan-policy-storage": "1.0 2.0",
       "users": "15.0 16.0",
-      "feesfines": "17.0 18.0 19.0",
+      "feesfines": "17.0 18.0 19.0"
+    },
+    "optionalOkapiInterfaces": {
       "circulation-bff-loans": "1.0"
     },
     "permissionSets": [
@@ -50,6 +52,7 @@
           "accounts.collection.get",
           "accounts.item.get",
           "lost-item-fees-policies.collection.get",
+          "circulation.check-in-by-barcode.post",
           "circulation-bff.loans.check-in-by-barcode.execute",
           "circulation.requests.collection.get",
           "feefineactions.collection.get",


### PR DESCRIPTION
## Purpose
Implement feature toggle for switch between `circulation/check-in-by-barcode` and `circulation-bff/loans/check-in-by-barcode`

`circulation/check-in-by-barcode` should be used when `stripes config enableEcsRequests` **absent**
`circulation-bff/loans/check-in-by-barcode` should be used when` stripes config enableEcsRequests` **present**

# Refs
https://issues.folio.org/browse/UICHKIN-439
