### PR TITLE
UICHKIN-460: Actions for check in item don't work

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * *BREAKING* Update stripes-* dependencies to latest version. Refs UICHKIN-452.
 * Implement support for fields without information. Refs UICHKIN-454.
 * Add support for new printing tokens in hold slips. Fixes UICHKIN-457.
+* Use `history.push` instead of `mutator.query` updating. Refs UICHKIN-460.
 
 ## [10.0.1] (https://github.com/folio-org/ui-checkin/tree/v10.0.1) (2025-01-23)
 [Full Changelog](https://github.com/folio-org/ui-checkin/compare/v10.0.0...v10.0.1)

--- a/src/CheckIn.js
+++ b/src/CheckIn.js
@@ -72,15 +72,15 @@ class CheckIn extends React.Component {
       app: PropTypes.arrayOf(PropTypes.object),
     }),
     mutator: PropTypes.shape({
-      query: PropTypes.shape({
-        update: PropTypes.func,
-      }),
       users: PropTypes.shape({
         GET: PropTypes.func,
       }),
     }).isRequired,
     loading: PropTypes.bool.isRequired,
     form: PropTypes.object.isRequired,
+    history: PropTypes.shape({
+      push: PropTypes.func.isRequired,
+    }).isRequired,
   };
 
   constructor(props) {
@@ -231,9 +231,7 @@ class CheckIn extends React.Component {
   }
 
   showLoanDetails(loan) {
-    this.props.mutator.query.update({
-      _path: `/users/view/${loan.userId}?layer=loan&loan=${loan.id}`,
-    });
+    this.props.history.push(`/users/view/${loan.userId}?layer=loan&loan=${loan.id}`);
   }
 
   showCheckinNotes(loan) {
@@ -241,9 +239,7 @@ class CheckIn extends React.Component {
   }
 
   showPatronDetails(loan) {
-    this.props.mutator.query.update({
-      _path: `/users/view/${loan.userId}`,
-    });
+    this.props.history.push(`/users/view/${loan.userId}`);
   }
 
   showRequestDetails(loan) {
@@ -255,9 +251,7 @@ class CheckIn extends React.Component {
       },
     } = loan;
 
-    this.props.mutator.query.update({
-      _path: `/requests/view/${requestID}`,
-    });
+    this.props.history.push(`/requests/view/${requestID}`);
   }
 
   showItemDetails(loan) {
@@ -270,7 +264,7 @@ class CheckIn extends React.Component {
     } = loan;
     const path = `/inventory/view/${instanceId}/${holdingsRecordId}/${id}`;
 
-    this.props.mutator.query.update({ _path: path });
+    this.props.history.push(path);
   }
 
   async newFeeFine(loan) {
@@ -285,7 +279,7 @@ class CheckIn extends React.Component {
     const pg = (patronGroups.find(p => p.id === patron) || {}).group;
     const path = `/users/view/${loan.userId}?filters=pg.${pg}&layer=charge&loan=${loan.id}`;
 
-    this.props.mutator.query.update({ _path: path });
+    this.props.history.push(path);
   }
 
   getTemplate(type) {
@@ -407,6 +401,7 @@ class CheckIn extends React.Component {
               userId={loan.userId}
               itemId={loan.itemId}
               mutator={this.props.mutator}
+              history={this.props.history}
             />
           </IfPermission>
           {loan.userId && !isVirtualUser &&

--- a/src/Checkin.test.js
+++ b/src/Checkin.test.js
@@ -50,9 +50,6 @@ const basicProps = {
     },
   },
   mutator: {
-    query: {
-      update: jest.fn(),
-    },
     users: {
       GET: jest.fn().mockResolvedValue([
         {
@@ -66,6 +63,9 @@ const basicProps = {
   showCheckinNotes: jest.fn(),
   loading: false,
   pristine: true,
+  history: {
+    push: jest.fn(),
+  },
 };
 const labelIds = {
   scannedItemsTitle: 'ui-checkin.scannedItems',
@@ -547,9 +547,7 @@ describe('CheckIn', () => {
 
         fireEvent.click(loanDetailsButton);
 
-        expect(basicProps.mutator.query.update).toHaveBeenCalledWith({
-          _path: `/users/view/${loan.userId}?layer=loan&loan=${loan.id}`,
-        });
+        expect(basicProps.history.push).toHaveBeenCalledWith(`/users/view/${loan.userId}?layer=loan&loan=${loan.id}`);
       });
 
       it('should update query pass after clicking on patron details button', () => {
@@ -557,9 +555,7 @@ describe('CheckIn', () => {
 
         fireEvent.click(patronDetailsButton);
 
-        expect(basicProps.mutator.query.update).toHaveBeenCalledWith({
-          _path: `/users/view/${loan.userId}`,
-        });
+        expect(basicProps.history.push).toHaveBeenCalledWith(`/users/view/${loan.userId}`);
       });
 
       it('should update query pass after clicking on item details button', () => {
@@ -567,9 +563,7 @@ describe('CheckIn', () => {
 
         fireEvent.click(itemDetailsButton);
 
-        expect(basicProps.mutator.query.update).toHaveBeenCalledWith({
-          _path: `/inventory/view/${loan.item.instanceId}/${loan.item.holdingsRecordId}/${loan.item.id}`,
-        });
+        expect(basicProps.history.push).toHaveBeenCalledWith(`/inventory/view/${loan.item.instanceId}/${loan.item.holdingsRecordId}/${loan.item.id}`);
       });
 
       it('should update query pass after clicking on request details button', () => {
@@ -577,9 +571,7 @@ describe('CheckIn', () => {
 
         fireEvent.click(requestDetailsButton);
 
-        expect(basicProps.mutator.query.update).toHaveBeenCalledWith({
-          _path: `/requests/view/${loan.staffSlipContext.request.requestID}`,
-        });
+        expect(basicProps.history.push).toHaveBeenCalledWith(`/requests/view/${loan.staffSlipContext.request.requestID}`);
       });
 
       it('should trigger get request to receive user information', () => {
@@ -600,9 +592,7 @@ describe('CheckIn', () => {
         fireEvent.click(newFeeFineButton);
 
         await waitFor(() => {
-          expect(basicProps.mutator.query.update).toHaveBeenCalledWith({
-            _path: `/users/view/${loan.userId}?filters=pg.${groupName}&layer=charge&loan=${loan.id}`,
-          });
+          expect(basicProps.history.push).toHaveBeenCalledWith(`/users/view/${loan.userId}?filters=pg.${groupName}&layer=charge&loan=${loan.id}`);
         });
       });
 

--- a/src/Scan.js
+++ b/src/Scan.js
@@ -85,9 +85,6 @@ class Scan extends React.Component {
         GET: PropTypes.func.isRequired,
         POST: PropTypes.func.isRequired,
       }),
-      query: PropTypes.shape({
-        update: PropTypes.func,
-      }),
       items: PropTypes.shape({
         GET: PropTypes.func,
         PUT: PropTypes.func,
@@ -133,7 +130,6 @@ class Scan extends React.Component {
   static manifest = Object.freeze({
     scannedItems: { initialValue: [] },
     checkInSession: { initialValue: {} },
-    query: { initialValue: {} },
     accounts: {
       type: 'okapi',
       accumulate: 'true',

--- a/src/components/FeeFineDetailsButton/FeeFineDetailsButton.js
+++ b/src/components/FeeFineDetailsButton/FeeFineDetailsButton.js
@@ -23,9 +23,9 @@ class FeeFineDetailsButton extends React.Component {
         GET: PropTypes.func.isRequired,
         cancel: PropTypes.func.isRequired,
       }).isRequired,
-      query: PropTypes.shape({
-        update: PropTypes.func.isRequired,
-      }).isRequired,
+    }).isRequired,
+    history: PropTypes.shape({
+      push: PropTypes.func.isRequired,
     }).isRequired,
   }
 
@@ -86,12 +86,10 @@ class FeeFineDetailsButton extends React.Component {
     event.stopPropagation();
 
     const {
-      mutator,
+      history,
     } = this.props;
 
-    mutator.query.update({
-      _path: this.getPath(),
-    });
+    history.push(this.getPath());
   };
 
   getPath = () => {

--- a/src/components/FeeFineDetailsButton/FeeFineDetailsButton.test.js
+++ b/src/components/FeeFineDetailsButton/FeeFineDetailsButton.test.js
@@ -11,7 +11,7 @@ import { loan as loanFixture } from '../../../test/jest/fixtures/loan';
 import FeeFineDetailsButton from './FeeFineDetailsButton';
 import { DCB_USER_LASTNAME } from '../../consts';
 
-const mockedQueryUpdate = jest.fn();
+const mockedHistoryPush = jest.fn();
 const labelIds = {
   feeFineDetails: 'ui-checkin.feeFineDetails',
 };
@@ -28,9 +28,9 @@ const renderFeeFineDetailsButton = (loan, accountData) => {
       GET: () => Promise.resolve(accountData),
       cancel: () => new Promise(jest.fn()),
     },
-    query: {
-      update: mockedQueryUpdate,
-    },
+  };
+  const history = {
+    push: mockedHistoryPush,
   };
   pushHistorySpy = jest.fn();
 
@@ -40,6 +40,7 @@ const renderFeeFineDetailsButton = (loan, accountData) => {
       itemId={itemId}
       mutator={parentMutator}
       onClick={pushHistorySpy}
+      history={history}
     />
   );
 };
@@ -94,16 +95,14 @@ describe('FeeFineDetailsButton', () => {
     const feeFineId = accountFixture.accounts[0].id;
 
     it('open fee/fine directly', async () => {
-      const expectedResult = {
-        _path: `/users/${userId}/accounts/view/${feeFineId}`,
-      };
+      const expectedResult = `/users/${userId}/accounts/view/${feeFineId}`;
 
       renderFeeFineDetailsButton(loanFixture, accountFixture);
 
       await waitFor(() => {
         fireEvent.click(screen.getByRole(buttonRole));
 
-        expect(mockedQueryUpdate).toHaveBeenLastCalledWith(expectedResult);
+        expect(mockedHistoryPush).toHaveBeenLastCalledWith(expectedResult);
       });
     });
 
@@ -120,16 +119,14 @@ describe('FeeFineDetailsButton', () => {
           diagnostics: [],
         },
       };
-      const expectedResult = {
-        _path: `/users/${userId}/accounts/open`,
-      };
+      const expectedResult = `/users/${userId}/accounts/open`;
 
       renderFeeFineDetailsButton(loanFixture, accountDataWithTwoOpenFeeFines);
 
       await waitFor(() => {
         fireEvent.click(screen.getByRole(buttonRole));
 
-        expect(mockedQueryUpdate).toHaveBeenLastCalledWith(expectedResult);
+        expect(mockedHistoryPush).toHaveBeenLastCalledWith(expectedResult);
       });
     });
 
@@ -149,16 +146,14 @@ describe('FeeFineDetailsButton', () => {
           diagnostics: [],
         },
       };
-      const expectedResult = {
-        _path: `/users/${userId}/accounts/view/closedFeeFineId`,
-      };
+      const expectedResult = `/users/${userId}/accounts/view/closedFeeFineId`;
 
       renderFeeFineDetailsButton(loanFixture, accountDataWithOneClosedFeeFine);
 
       await waitFor(() => {
         fireEvent.click(screen.getByRole(buttonRole));
 
-        expect(mockedQueryUpdate).toHaveBeenLastCalledWith(expectedResult);
+        expect(mockedHistoryPush).toHaveBeenLastCalledWith(expectedResult);
       });
     });
 
@@ -181,16 +176,14 @@ describe('FeeFineDetailsButton', () => {
           diagnostics: [],
         },
       };
-      const expectedResult = {
-        _path: `/users/${userId}/accounts/closed`,
-      };
+      const expectedResult = `/users/${userId}/accounts/closed`;
 
       renderFeeFineDetailsButton(loanFixture, accountDataWithTwoClosedFeeFines);
 
       await waitFor(() => {
         fireEvent.click(screen.getByRole(buttonRole));
 
-        expect(mockedQueryUpdate).toHaveBeenLastCalledWith(expectedResult);
+        expect(mockedHistoryPush).toHaveBeenLastCalledWith(expectedResult);
       });
     });
   });


### PR DESCRIPTION
## Purpose
By some reason  `mutator.query.update` does not have any impact on current application url. 
In the scope of this PR I use `history.push` instead of `mutator.query.update`.

## Refs
[UICHKIN-460](https://folio-org.atlassian.net/browse/UICHKIN-460)