### PR TITLE
UI-CHKIN-512: Cannot start the module in standalone mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change history for ui-checkin
 
+## IN PROGRESS
+
+* Version bumps for `@folio/stripes-webpack`, automatically set service point in development mode. Refs UICHKIN-512.
+
 ## [12.0.0] (https://github.com/folio-org/ui-checkin/tree/v12.0.0) (2026-04-16)
 [Full Changelog](https://github.com/folio-org/ui-checkin/compare/v11.0.3...v12.0.0)
 

--- a/package.json
+++ b/package.json
@@ -84,10 +84,10 @@
   "devDependencies": {
     "@babel/core": "^7.17.12",
     "@babel/eslint-parser": "^7.17.0",
-    "@folio/eslint-config-stripes": "^8.0.0",
-    "@folio/jest-config-stripes": "^3.0.0",
+    "@folio/eslint-config-stripes": "^9.0.0",
+    "@folio/jest-config-stripes": "^3.1.0",
     "@folio/stripes": "^10.0.0",
-    "@folio/stripes-cli": "^4.0.0",
+    "@folio/stripes-cli": "^5.0.0",
     "@folio/stripes-components": "^13.0.0",
     "@folio/stripes-core": "^11.0.0",
     "@folio/stripes-testing": "^5.0.0",
@@ -124,5 +124,8 @@
     "react-dom": "^18.2.0",
     "react-intl": "^7.1.5",
     "react-router-dom": "^5.2.0"
+  },
+  "resolutions": {
+    "@folio/stripes-webpack": "^7.0.1"
   }
 }

--- a/src/CheckIn.js
+++ b/src/CheckIn.js
@@ -91,10 +91,11 @@ class CheckIn extends React.Component {
     barcodeRef: PropTypes.shape({
       current: PropTypes.instanceOf(Element),
     }),
-    checkinFormRef: PropTypes.oneOfType([
-      PropTypes.func,
-      PropTypes.shape({ current: PropTypes.instanceOf(Element) }),
-    ]),
+    checkinFormRef: PropTypes.shape({ current: PropTypes.shape({
+      change: PropTypes.func.isRequired,
+      getState: PropTypes.func.isRequired,
+      reset: PropTypes.func.isRequired,
+    }) }).isRequired,
     onSessionEnd: PropTypes.func,
     resources: PropTypes.shape({
       checkinSettings: PropTypes.shape({
@@ -135,8 +136,9 @@ class CheckIn extends React.Component {
     }).isRequired,
     loading: PropTypes.bool.isRequired,
     form: PropTypes.shape({
-      change: PropTypes.func,
-      getState: PropTypes.func,
+      change: PropTypes.func.isRequired,
+      getState: PropTypes.func.isRequired,
+      reset: PropTypes.func.isRequired,
     }).isRequired,
     history: PropTypes.shape({
       push: PropTypes.func.isRequired,

--- a/src/Scan.js
+++ b/src/Scan.js
@@ -13,6 +13,7 @@ import {
 } from 'lodash';
 import { v4 as uuidv4 } from 'uuid';
 
+import { updateUser } from '@folio/stripes/core';
 import {
   escapeCqlValue,
   convertToSlipData,
@@ -331,10 +332,48 @@ export class Scan extends React.Component {
     };
   }
 
+  componentDidMount() {
+    if (process.env.NODE_ENV === 'development') { // Since we only want the behavior in local development mode
+      this.seedServicePointIfMissing();
+    }
+  }
+
+  componentDidUpdate() {
+    if (process.env.NODE_ENV === 'development') { // Since we only want the behavior in local development mode
+      this.seedServicePointIfMissing();
+    }
+  }
+
   store = this.props.stripes.store;
   barcode = React.createRef();
   checkInData = null;
   checkinFormRef = React.createRef();
+  servicePointSeeded = false;
+
+  /**
+   * Standalone ui-checkin has no ui-users to seed the session, so the logged-in
+   * user has no curServicePoint: the app would otherwise spin on <Loading />
+   * forever, and check-in-by-barcode would post an empty servicePointId. Once the
+   * service points have loaded, default to the first one. In a full platform this
+   * never runs, since a service point is already selected via the profile menu.
+   */
+  seedServicePointIfMissing = () => {
+    if (this.servicePointSeeded) {
+      return;
+    }
+
+    if (this.props.stripes?.user?.user?.curServicePoint?.id) {
+      return;
+    }
+
+    const servicePoints = this.props.resources?.servicePoints?.records;
+    if (!servicePoints?.length) {
+      return;
+    }
+
+    this.servicePointSeeded = true;
+    updateUser(this.store, { curServicePoint: servicePoints[0] });
+  };
 
   setFocusInput = () => {
     this.barcode.current.focus();

--- a/src/Scan.test.js
+++ b/src/Scan.test.js
@@ -330,8 +330,27 @@ jest.mock('./util', () => ({
 jest.spyOn(React, 'createRef').mockReturnValue(createRefMock);
 
 describe('Scan', () => {
+  const originalNodeEnv = process.env.NODE_ENV;
+
   afterEach(() => {
+    process.env.NODE_ENV = originalNodeEnv;
     jest.clearAllMocks();
+  });
+
+  it('should only seed the service point in development mode', () => {
+    const instance = new RawScan(basicProps);
+    const seedSpy = jest.spyOn(instance, 'seedServicePointIfMissing').mockImplementation(() => {});
+
+    process.env.NODE_ENV = 'production';
+    instance.componentDidMount();
+    instance.componentDidUpdate();
+    expect(seedSpy).not.toHaveBeenCalled();
+
+    process.env.NODE_ENV = 'development';
+    seedSpy.mockClear();
+    instance.componentDidMount();
+    instance.componentDidUpdate();
+    expect(seedSpy).toHaveBeenCalledTimes(2);
   });
 
   describe('getLoanForItem', () => {


### PR DESCRIPTION
<!--
  If you have a relevant JIRA issue number, please put it in the issue title.
  Example: UICHKIN-233: Add pull request template
-->

<!--
  You have added reviewers to the pull request.
  Required reviewers this is a personal that responsible for current repository
  in according with https://wiki.folio.org/display/REL/Team+vs+module+responsibility+matrix
-->

## Purpose
<!--
  Why are you making this change? There is nothing more important
  to provide to the reviewer and to future readers than the cause
  that gave rise to this pull request. Be careful to avoid circular
  statements like "the purpose is to update the schema." and
  instead provide an explanation like "there is more data to be provided and stored for Purchase Orders
  which is currently missing in the schema"

  The purpose may seem self-evident to you now, but the standard to
  hold yourself to should be "can a developer parachuting into this
  project reconstruct the necessary context merely by reading this
  section."
 -->

When doing a fresh install and try to `yarn start ...` you are running into multiple problems. This PR tries to address those. See here for the corresponding ticket: https://folio-org.atlassian.net/browse/UICHKIN-512

## Approach
<!--
 How does this change fulfill the purpose? It's best to talk
 high-level strategy and avoid code-splaining the commit history.

 The goal is not only to explain what you did, but help other
 developers *work* with your solution in the future.
-->

### (1) Dependencies and upstream bugs

The `package.json` contains outdated package versions and needs to be updated, due to an upstream bug in `stripes-webpack`. Notice the temporary fix of the version resolution of `@folio/stripes-webpack` to prevent `@folio/stripes-testing` from pulling in an outdated version again.

### (2) Missing service point when “Scan“ component is mounted

When starting in standalone mode, the app won’t finish to load unless we seed it with a service point.